### PR TITLE
[fix] Remove display of internal pods from `apps` method

### DIFF
--- a/apps
+++ b/apps
@@ -11,7 +11,7 @@ function apps() {
   app_name="$1"
   say "Getting app list"
 
-  kubectl get pod -n eirini-workloads
+  kubectl get pod -n eirini-workloads | grep -v 'staging-listener\|staging-pipeline'
 }
 
 apps


### PR DESCRIPTION
See #18 in the `apps` bash script.

:warning: Note that the go code in the `installer` branch needs a different fix (assuming that the functionality is already present).

This is the reason this PR is not marked as fixing the issue.
