### PR TITLE
Tests and Fixes

### DIFF
--- a/cli/cmd/install.go
+++ b/cli/cmd/install.go
@@ -4,7 +4,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/deployments"
@@ -30,21 +29,7 @@ func RegisterInstall(rootCmd *cobra.Command) {
 	installCmd.Flags().BoolP("non-interactive", "n", false, "Whether to ask the user or not")
 
 	installer.GatherNeededOptions()
-	for _, opt := range installer.NeededOptions {
-		// Translate option name
-		flagName := strings.ReplaceAll(opt.Name, "_", "-")
-
-		// Declare option's flag, type-dependent
-		switch opt.Type {
-		case kubernetes.BooleanType:
-			installCmd.Flags().Bool(flagName, opt.Default.(bool), opt.Description)
-		case kubernetes.StringType:
-			installCmd.Flags().String(flagName, opt.Default.(string), opt.Description)
-		case kubernetes.IntType:
-			installCmd.Flags().Int(flagName, opt.Default.(int), opt.Description)
-		}
-	}
-
+	installer.NeededOptions.AsCobraFlagsFor(installCmd)
 	rootCmd.AddCommand(installCmd)
 }
 

--- a/cli/kubernetes/cli_options_reader.go
+++ b/cli/kubernetes/cli_options_reader.go
@@ -16,10 +16,10 @@ func NewCLIOptionsReader(cmd *cobra.Command) CLIOptionsReader {
 	return CLIOptionsReader{cmd: cmd}
 }
 
-// Read queries the cobra command for a cli options associated with
-// the given InstallationOption and returns its value converted to the
+// Queries the cobra command for a flag associated with the given
+// InstallationOption and returns its value converted to the
 // appropriate (Go) type as defined by the Type field of the
-// InstallationOption.
+// InstallationOption. Does nothing if no cobra flag is found.
 func (reader CLIOptionsReader) Read(option *InstallationOption) error {
 	// Translate option name
 	flagName := strings.ReplaceAll(option.Name, "_", "-")
@@ -33,6 +33,13 @@ func (reader CLIOptionsReader) Read(option *InstallationOption) error {
 	// documentation has not shown me a way to properly determine
 	// if a flag was not used on the command line at all,
 	// vs. specified with (possibly the default) value.
+	//
+	// Do nothing if the specified option has no associated cobra
+	// flag.
+
+	if reader.cmd.Flags().Lookup(flagName) == nil {
+		return nil
+	}
 
 	var cliValue interface{}
 	var cliValid bool

--- a/cli/kubernetes/cli_options_reader.go
+++ b/cli/kubernetes/cli_options_reader.go
@@ -48,13 +48,13 @@ func (reader CLIOptionsReader) Read(option *InstallationOption) error {
 	switch option.Type {
 	case BooleanType:
 		cliValue, err = reader.cmd.Flags().GetBool(flagName)
-		cliValid = (err != nil) || (cliValue.(bool) != option.Default.(bool))
+		cliValid = (err == nil) && (cliValue.(bool) != option.Default.(bool))
 	case StringType:
 		cliValue, err = reader.cmd.Flags().GetString(flagName)
-		cliValid = (err != nil) || (cliValue.(string) != option.Default.(string))
+		cliValid = (err == nil) && (cliValue.(string) != option.Default.(string))
 	case IntType:
 		cliValue, err = reader.cmd.Flags().GetInt(flagName)
-		cliValid = (err != nil) || (cliValue.(int) != option.Default.(int))
+		cliValid = (err == nil) && (cliValue.(int) != option.Default.(int))
 	}
 
 	if err != nil {

--- a/cli/kubernetes/cli_options_reader_test.go
+++ b/cli/kubernetes/cli_options_reader_test.go
@@ -1,0 +1,174 @@
+package kubernetes_test
+
+import (
+	"github.com/spf13/cobra"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/suse/carrier/cli/kubernetes"
+)
+
+var _ = Describe("CLIOptionsReader", func() {
+
+	// We have two of each option/flag. Required because the
+	// reader will modify the structure (set fields Value and
+	// UserSpecified) when things are ok. The other definition is
+	// for when defaults are seen, with proper initial values for
+	// all fields. And to prevent concurrent access to the same
+	// structure by concurrent tests.
+
+	optionFlag := InstallationOption{
+		Name:         "a_flag",
+		DeploymentID: "",
+		Default:      true,
+		Type:         BooleanType,
+	}
+
+	optionFlagD := InstallationOption{
+		Name:         "a_flag_d",
+		DeploymentID: "",
+		Default:      true,
+		Type:         BooleanType,
+	}
+
+	optionString := InstallationOption{
+		Name:         "a_text",
+		DeploymentID: "",
+		Default:      "",
+		Type:         StringType,
+	}
+
+	optionStringD := InstallationOption{
+		Name:         "a_text_d",
+		DeploymentID: "",
+		Default:      "",
+		Type:         StringType,
+	}
+
+	optionInt := InstallationOption{
+		Name:         "a_count",
+		DeploymentID: "",
+		Default:      -1,
+		Type:         IntType,
+	}
+
+	optionIntD := InstallationOption{
+		Name:         "a_count_d",
+		DeploymentID: "",
+		Default:      -1,
+		Type:         IntType,
+	}
+
+	optionUnknown := InstallationOption{
+		Name:         "without_a_cobra_flag",
+		DeploymentID: "",
+		Default:      -1,
+		Type:         IntType,
+	}
+
+	dummyCmd := &cobra.Command{
+		Use:   "dummy",
+		Short: "test dummy",
+		Long:  `this is a test dummy`,
+	}
+
+	dummyDefaultCmd := &cobra.Command{
+		Use:   "dummy defaults",
+		Short: "test dummy, flag defaults",
+		Long:  `this is a test dummy for defaults`,
+	}
+
+	var options InstallationOptions = []InstallationOption{
+		optionFlag,
+		optionString,
+		optionInt,
+	}
+
+	var optionsD InstallationOptions = []InstallationOption{
+		optionFlagD,
+		optionStringD,
+		optionIntD,
+	}
+
+	options.AsCobraFlagsFor(dummyCmd)
+	reader := NewCLIOptionsReader(dummyCmd)
+
+	optionsD.AsCobraFlagsFor(dummyDefaultCmd)
+	readerDefaults := NewCLIOptionsReader(dummyDefaultCmd)
+
+	options = append(options, optionUnknown)
+
+	// Fake having seen the flags on the command line.
+	_ = dummyCmd.Flags().Set("a-flag", "false")
+	_ = dummyCmd.Flags().Set("a-text", "some text")
+	_ = dummyCmd.Flags().Set("a-count", "888")
+
+	// Nothing to fake for dummyDefaultCmd, we want it to return
+	// the flag defaults.
+
+	Describe("Read", func() {
+		When("handling an option without flag", func() {
+			It("it does nothing", func() {
+				err := reader.Read(&optionUnknown)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(optionUnknown.UserSpecified).To(BeFalse())
+				Expect(optionUnknown.Value).To(BeNil())
+			})
+		})
+
+		When("handling a boolean flag", func() {
+			It("returns a boolean", func() {
+				err := reader.Read(&optionFlag)
+				Expect(err).ToNot(HaveOccurred())
+				resultBool, ok := optionFlag.Value.(bool)
+				Expect(ok).To(BeTrue())
+				Expect(resultBool).To(BeFalse())
+				Expect(optionFlag.UserSpecified).To(BeTrue())
+			})
+
+			It("does nothing for defaults", func() {
+				err := readerDefaults.Read(&optionFlagD)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(optionFlagD.Value).To(BeNil())
+				Expect(optionFlagD.UserSpecified).To(BeFalse())
+			})
+		})
+
+		When("handling a string flag", func() {
+			It("returns a string", func() {
+				err := reader.Read(&optionString)
+				Expect(err).ToNot(HaveOccurred())
+				resultString, ok := optionString.Value.(string)
+				Expect(ok).To(BeTrue())
+				Expect(resultString).To(Equal("some text"))
+				Expect(optionString.UserSpecified).To(BeTrue())
+			})
+
+			It("does nothing for defaults", func() {
+				err := readerDefaults.Read(&optionStringD)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(optionStringD.Value).To(BeNil())
+				Expect(optionStringD.UserSpecified).To(BeFalse())
+			})
+		})
+
+		When("handling an integer flag", func() {
+			It("returns an integer", func() {
+				err := reader.Read(&optionInt)
+				Expect(err).ToNot(HaveOccurred())
+				resultInt, ok := optionInt.Value.(int)
+				Expect(ok).To(BeTrue())
+				Expect(resultInt).To(Equal(888))
+				Expect(optionInt.UserSpecified).To(BeTrue())
+			})
+
+			It("does nothing for defaults", func() {
+				err := readerDefaults.Read(&optionIntD)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(optionIntD.Value).To(BeNil())
+				Expect(optionIntD.UserSpecified).To(BeFalse())
+			})
+		})
+	})
+})

--- a/cli/kubernetes/cli_options_reader_test.go
+++ b/cli/kubernetes/cli_options_reader_test.go
@@ -109,7 +109,7 @@ var _ = Describe("CLIOptionsReader", func() {
 
 	Describe("Read", func() {
 		When("handling an option without flag", func() {
-			It("it does nothing", func() {
+			It("does nothing", func() {
 				err := reader.Read(&optionUnknown)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(optionUnknown.UserSpecified).To(BeFalse())

--- a/cli/kubernetes/default_options_reader_test.go
+++ b/cli/kubernetes/default_options_reader_test.go
@@ -42,17 +42,17 @@ var _ = Describe("DefaultOptionsReader", func() {
 			},
 		}
 
-		It("it prefers the DynDefaultFunc over a static Default", func() {
+		It("prefers the DynDefaultFunc over a static Default", func() {
 			Expect(reader.Read(&optionDynamic)).To(BeNil())
 			Expect(optionDynamic.Value).To(Equal("Hello"))
 		})
 
-		It("it uses a static Default", func() {
+		It("uses a static Default", func() {
 			Expect(reader.Read(&optionStatic)).To(BeNil())
 			Expect(optionStatic.Value).To(Equal("World"))
 		})
 
-		It("it reports errors returned from the DynDefaultFunc", func() {
+		It("reports errors returned from the DynDefaultFunc", func() {
 			err := reader.Read(&optionError)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("an error"))

--- a/cli/kubernetes/default_options_reader_test.go
+++ b/cli/kubernetes/default_options_reader_test.go
@@ -1,0 +1,61 @@
+package kubernetes_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/suse/carrier/cli/kubernetes"
+)
+
+var _ = Describe("DefaultOptionsReader", func() {
+	reader := NewDefaultOptionsReader()
+
+	Describe("Read", func() {
+		// The tests here are essentially a copy of the tests
+		// for `SetDefault` in files `options(_test).go`.  Any
+		// new tests there should be replicated here.
+
+		optionDynamic := InstallationOption{
+			Name:         "TheName",
+			DeploymentID: "SomeDeployment",
+			Default:      "World",
+			DynDefaultFunc: func(o *InstallationOption) error {
+				o.Value = "Hello"
+				return nil
+			},
+		}
+
+		optionStatic := InstallationOption{
+			Name:         "TheName",
+			DeploymentID: "SomeDeployment",
+			Default:      "World",
+		}
+
+		optionError := InstallationOption{
+			Name:         "TheName",
+			DeploymentID: "SomeDeployment",
+			DynDefaultFunc: func(o *InstallationOption) error {
+				o.Value = "Hello"
+				return errors.New("an error")
+			},
+		}
+
+		It("it prefers the DynDefaultFunc over a static Default", func() {
+			Expect(reader.Read(&optionDynamic)).To(BeNil())
+			Expect(optionDynamic.Value).To(Equal("Hello"))
+		})
+
+		It("it uses a static Default", func() {
+			Expect(reader.Read(&optionStatic)).To(BeNil())
+			Expect(optionStatic.Value).To(Equal("World"))
+		})
+
+		It("it reports errors returned from the DynDefaultFunc", func() {
+			err := reader.Read(&optionError)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("an error"))
+		})
+	})
+})

--- a/cli/kubernetes/interactive_options_reader.go
+++ b/cli/kubernetes/interactive_options_reader.go
@@ -25,6 +25,16 @@ func NewInteractiveOptionsReader(stdout io.Writer, stdin io.Reader) InteractiveO
 // returns that value validated and converted to the appropriate type as defined
 // by the Type field of the InstallationOption.
 func (reader InteractiveOptionsReader) Read(option *InstallationOption) error {
+
+	// Internal validation of Type field early. Prevent bogus prompting.
+	switch option.Type {
+	case BooleanType:
+	case StringType:
+	case IntType:
+	default:
+		return errors.New("Internal error: option Type not supported")
+	}
+
 	// Ignore anything which is already set by the user (cli option or similar).
 	if option.UserSpecified {
 		return nil
@@ -58,7 +68,9 @@ func (reader InteractiveOptionsReader) Read(option *InstallationOption) error {
 	userValue = strings.TrimSpace(userValue)
 
 	if userValue == "" {
-		// Keep the default set by (**).
+		// Keep the default set by (**). And claim it as
+		// user-specified (actually more `affirmed`).
+		option.UserSpecified = true
 		return nil
 	}
 
@@ -112,6 +124,6 @@ func (reader InteractiveOptionsReader) Read(option *InstallationOption) error {
 			userValue = strings.TrimSpace(userValue)
 		}
 	default:
-		return errors.New("option Type not supported")
+		return errors.New("Internal error: option Type not supported")
 	}
 }

--- a/cli/kubernetes/interactive_options_reader_test.go
+++ b/cli/kubernetes/interactive_options_reader_test.go
@@ -22,7 +22,47 @@ var _ = Describe("InteractiveOptionsReader", func() {
 		Type:        StringType,
 	}
 
+	optionSpecified := InstallationOption{
+		Name:          "Option",
+		Value:         "User Specified Dummy",
+		Description:   "This option got a user specified value",
+		Type:          StringType,
+		UserSpecified: true,
+	}
+
+	optionDefault := InstallationOption{
+		Name:        "Option",
+		Value:       "",
+		Default:     "Hello World",
+		Description: "This is a very needed option",
+		Type:        StringType,
+	}
+
+	optionDefaultKeep := InstallationOption{
+		Name:        "Option",
+		Value:       "",
+		Default:     "Hello World",
+		Description: "This is a very needed option",
+		Type:        StringType,
+	}
+
 	Describe("Read", func() {
+		It("ignores an option with a user-specified value", func() {
+			err := reader.Read(&optionSpecified)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that there was neither prompt nor other output
+			prompt, err := ioutil.ReadAll(stdout)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(prompt)).To(Equal(""))
+
+			// Verify that the option value was not touched
+			resultStr, ok := optionSpecified.Value.(string)
+			Expect(ok).To(BeTrue())
+			Expect(resultStr).To(Equal("User Specified Dummy"))
+			Expect(optionSpecified.UserSpecified).To(BeTrue())
+		})
+
 		It("prompts the user for input on stdin", func() {
 			stdin.Write([]byte("userDefinedValue\n"))
 			err := reader.Read(&option)
@@ -36,6 +76,39 @@ var _ = Describe("InteractiveOptionsReader", func() {
 			resultStr, ok := option.Value.(string)
 			Expect(ok).To(BeTrue())
 			Expect(resultStr).To(Equal("userDefinedValue"))
+			Expect(option.UserSpecified).To(BeTrue())
+		})
+
+		It("shows the default in the prompt", func() {
+			stdin.Write([]byte("userDefinedValue\n"))
+			err := reader.Read(&optionDefault)
+			Expect(err).ToNot(HaveOccurred())
+
+			prompt, err := ioutil.ReadAll(stdout)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(prompt)).To(ContainSubstring("Hello World"))
+
+			resultStr, ok := optionDefault.Value.(string)
+			Expect(ok).To(BeTrue())
+			Expect(resultStr).To(Equal("userDefinedValue"))
+			Expect(optionDefault.UserSpecified).To(BeTrue())
+		})
+
+		It("keeps the default when no value is entered by the user", func() {
+			stdin.Write([]byte("\n"))
+			err := reader.Read(&optionDefaultKeep)
+			Expect(err).ToNot(HaveOccurred())
+
+			prompt, err := ioutil.ReadAll(stdout)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(prompt)).To(ContainSubstring("Hello World"))
+
+			resultStr, ok := optionDefaultKeep.Value.(string)
+			Expect(ok).To(BeTrue())
+			Expect(resultStr).To(Equal("Hello World"))
+			Expect(optionDefaultKeep.UserSpecified).To(BeTrue())
 		})
 
 		When("the option is BooleanType", func() {
@@ -58,6 +131,7 @@ var _ = Describe("InteractiveOptionsReader", func() {
 				resultBool, ok := option.Value.(bool)
 				Expect(ok).To(BeTrue())
 				Expect(resultBool).To(BeTrue())
+				Expect(option.UserSpecified).To(BeTrue())
 			})
 
 			It("asks again if the answer is not 'y' or 'n'", func() {
@@ -73,6 +147,66 @@ var _ = Describe("InteractiveOptionsReader", func() {
 				resultBool, ok := option.Value.(bool)
 				Expect(ok).To(BeTrue())
 				Expect(resultBool).To(BeTrue())
+				Expect(option.UserSpecified).To(BeTrue())
+			})
+		})
+
+		When("the option is IntType", func() {
+			var option InstallationOption
+
+			BeforeEach(func() {
+				option = InstallationOption{
+					Name:        "Option",
+					Value:       "",
+					Description: "This is an integer option",
+					Type:        IntType,
+				}
+			})
+
+			It("returns an integer", func() {
+				stdin.Write([]byte("55\n"))
+				err := reader.Read(&option)
+				Expect(err).ToNot(HaveOccurred())
+
+				resultInt, ok := option.Value.(int)
+				Expect(ok).To(BeTrue())
+				Expect(resultInt).To(Equal(55))
+				Expect(option.UserSpecified).To(BeTrue())
+			})
+
+			It("asks again if the answer is not an integer", func() {
+				stdin.Write([]byte("other\n66\n"))
+				err := reader.Read(&option)
+				Expect(err).ToNot(HaveOccurred())
+
+				prompt, err := ioutil.ReadAll(stdout)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(prompt)).To(
+					ContainSubstring("Please provide an integer value"))
+
+				resultInt, ok := option.Value.(int)
+				Expect(ok).To(BeTrue())
+				Expect(resultInt).To(Equal(66))
+				Expect(option.UserSpecified).To(BeTrue())
+			})
+		})
+
+		When("the option is bogus", func() {
+			var option InstallationOption
+
+			BeforeEach(func() {
+				option = InstallationOption{
+					Name:        "Option",
+					Value:       "",
+					Description: "This is a bogus option with a bogus type",
+					Type:        22,
+				}
+			})
+
+			It("returns an error", func() {
+				err := reader.Read(&option)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Internal error: option Type not supported"))
 			})
 		})
 	})

--- a/cli/kubernetes/options.go
+++ b/cli/kubernetes/options.go
@@ -48,11 +48,23 @@ func (opts InstallationOptions) AsCobraFlagsFor(cmd *cobra.Command) {
 		// Declare option's flag, type-dependent
 		switch opt.Type {
 		case BooleanType:
-			cmd.Flags().Bool(flagName, opt.Default.(bool), opt.Description)
+			if opt.Default == nil {
+				cmd.Flags().Bool(flagName, false, opt.Description)
+			} else {
+				cmd.Flags().Bool(flagName, opt.Default.(bool), opt.Description)
+			}
 		case StringType:
-			cmd.Flags().String(flagName, opt.Default.(string), opt.Description)
+			if opt.Default == nil {
+				cmd.Flags().String(flagName, "", opt.Description)
+			} else {
+				cmd.Flags().String(flagName, opt.Default.(string), opt.Description)
+			}
 		case IntType:
-			cmd.Flags().Int(flagName, opt.Default.(int), opt.Description)
+			if opt.Default == nil {
+				cmd.Flags().Int(flagName, 0, opt.Description)
+			} else {
+				cmd.Flags().Int(flagName, opt.Default.(int), opt.Description)
+			}
 		}
 	}
 	return

--- a/cli/kubernetes/options.go
+++ b/cli/kubernetes/options.go
@@ -3,6 +3,9 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -36,6 +39,24 @@ type InstallationOption struct {
 }
 
 type InstallationOptions []InstallationOption
+
+func (opts InstallationOptions) AsCobraFlagsFor(cmd *cobra.Command) {
+	for _, opt := range opts {
+		// Translate option name
+		flagName := strings.ReplaceAll(opt.Name, "_", "-")
+
+		// Declare option's flag, type-dependent
+		switch opt.Type {
+		case BooleanType:
+			cmd.Flags().Bool(flagName, opt.Default.(bool), opt.Description)
+		case StringType:
+			cmd.Flags().String(flagName, opt.Default.(string), opt.Description)
+		case IntType:
+			cmd.Flags().Int(flagName, opt.Default.(int), opt.Description)
+		}
+	}
+	return
+}
 
 func (opts InstallationOptions) ToOptMap() map[string]InstallationOption {
 	result := map[string]InstallationOption{}

--- a/cli/kubernetes/options_test.go
+++ b/cli/kubernetes/options_test.go
@@ -29,7 +29,7 @@ var _ = Describe("InstallationOption", func() {
 				return nil
 			},
 		}
-		It("it calls the DynDefaultFunc", func() {
+		It("calls the DynDefaultFunc", func() {
 			Expect(option.DynDefault()).To(BeNil())
 			Expect(option.Value).To(Equal("Hello"))
 		})
@@ -64,17 +64,17 @@ var _ = Describe("InstallationOption", func() {
 			},
 		}
 
-		It("it prefers the DynDefaultFunc over a static Default", func() {
+		It("prefers the DynDefaultFunc over a static Default", func() {
 			Expect(optionDynamic.SetDefault()).To(BeNil())
 			Expect(optionDynamic.Value).To(Equal("Hello"))
 		})
 
-		It("it uses a static Default", func() {
+		It("uses a static Default", func() {
 			Expect(optionStatic.SetDefault()).To(BeNil())
 			Expect(optionStatic.Value).To(Equal("World"))
 		})
 
-		It("it reports errors returned from the DynDefaultFunc", func() {
+		It("reports errors returned from the DynDefaultFunc", func() {
 			err := optionError.SetDefault()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("an error"))


### PR DESCRIPTION
Followup on PR #30 for Ticket #29.

Mainly extending the testsuites for all the new functionality.
This also fixes issues in the CLIOptionsReader not seen before and luckily not breaking the usage of `install` in the GA flow.
Because the issue found was not triggered in the manual testing of cli processing.
:+1: for testsuites.
Generally added some more checks to the code itself, in various places.

