### PR TITLE
Fixed data races in the use of the spinners.

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -9,7 +9,7 @@ build-arm64: lint
 	GOARCH="arm64" GOOS="linux" go build -o dist/carrier-linux-arm64
 
 build-amd64: lint
-	GOARCH="amd64" GOOS="linux" go build -o dist/carrier-linux-amd64
+	GOARCH="amd64" GOOS="linux" go build -race -o dist/carrier-linux-amd64
 
 build-windows: lint
 	GOARCH="amd64" GOOS="windows" go build -o dist/carrier-windows-amd64

--- a/cli/helpers/exec.go
+++ b/cli/helpers/exec.go
@@ -103,11 +103,10 @@ func Kubectl(command string) (string, error) {
 }
 
 func SpinnerWaitCommand(message string, funk ExternalCommandFunc) (string, error) {
-	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond) // Build our new spinner
-	s.Start()                                                    // Start the spinner
+	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond) // Build our new spinner,
+	s.Suffix = emoji.Sprintf(" %s :zzz:", message)               // configure, and
+	s.Start()                                                    // start it
 	defer s.Stop()
-
-	s.Suffix = emoji.Sprintf(" %s :zzz:", message)
 
 	return funk()
 }

--- a/cli/kubernetes/cluster.go
+++ b/cli/kubernetes/cluster.go
@@ -162,9 +162,9 @@ func (c *Cluster) ListPods(namespace, selector string) (*v1.PodList, error) {
 // Returns an error if no pods are found or not all discovered pods enter running state.
 func (c *Cluster) WaitUntilPodBySelectorExist(namespace, selector string, timeout int) error {
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond) // Build our new spinner
-	s.Start()                                                    // Start the spinner
-	defer s.Stop()
 	s.Suffix = emoji.Sprintf(" Waiting for resource %s to be created in %s ... :zzz: ", selector, namespace)
+	s.Start() // Start the spinner
+	defer s.Stop()
 	return wait.PollImmediate(time.Second, time.Duration(timeout)*time.Second, c.podExists(namespace, selector))
 }
 
@@ -173,9 +173,9 @@ func (c *Cluster) WaitUntilPodBySelectorExist(namespace, selector string, timeou
 // found or not all discovered pods enter running state.
 func (c *Cluster) WaitForPodBySelectorRunning(namespace, selector string, timeout int) error {
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond) // Build our new spinner
-	s.Start()                                                    // Start the spinner
-	defer s.Stop()
 	s.Suffix = emoji.Sprintf(" Waiting for resource %s to be running in %s ... :zzz: ", selector, namespace)
+	s.Start() // Start the spinner
+	defer s.Stop()
 	podList, err := c.ListPods(namespace, selector)
 	if err != nil {
 		return errors.Wrapf(err, "failed listingpods with selector %s", selector)
@@ -186,7 +186,9 @@ func (c *Cluster) WaitForPodBySelectorRunning(namespace, selector string, timeou
 	}
 
 	for _, pod := range podList.Items {
+		s.Stop()
 		s.Suffix = emoji.Sprintf(" Waiting for pod %s to be running in %s ... :zzz: ", pod.Name, namespace)
+		s.Start()
 		if err := c.WaitForPodRunning(namespace, pod.Name, time.Duration(timeout)*time.Second); err != nil {
 			return errors.Wrapf(err, "failed waiting for %s", pod.Name)
 		}


### PR DESCRIPTION
Noted possibility in code review, confirmed by activating -race for build.
Confirmed possible fix as working.