### PR TITLE
[fix] Added waiting for pod existence before waiting for running.

### DIFF
--- a/cli/deployments/eirini.go
+++ b/cli/deployments/eirini.go
@@ -148,8 +148,14 @@ func (k Eirini) apply(c kubernetes.Cluster, options kubernetes.InstallationOptio
 		return err
 	}
 
+	if err := c.WaitUntilPodBySelectorExist("eirini-core", "name=eirini-api", k.Timeout); err != nil {
+		return errors.Wrap(err, "failed waiting Eirini api deployment to exist")
+	}
 	if err := c.WaitForPodBySelectorRunning("eirini-core", "name=eirini-api", k.Timeout); err != nil {
 		return errors.Wrap(err, "failed waiting Eirini api deployment to come up")
+	}
+	if err := c.WaitUntilPodBySelectorExist("eirini-core", "name=eirini-metrics", k.Timeout); err != nil {
+		return errors.Wrap(err, "failed waiting Eirini metrics deployment to exist")
 	}
 	if err := c.WaitForPodBySelectorRunning("eirini-core", "name=eirini-metrics", k.Timeout); err != nil {
 		return errors.Wrap(err, "failed waiting Eirini metrics deployment to come up")


### PR DESCRIPTION
Without that the cli can be to fast in looking for pods, and abort `install` when it doesn't find any, while the cluster busily works on setting things up.