### PR TITLE
Fixed more race conditions in the `install` method.

### DIFF
--- a/cli/deployments/eirini.go
+++ b/cli/deployments/eirini.go
@@ -169,17 +169,16 @@ func (k Eirini) apply(c kubernetes.Cluster, options kubernetes.InstallationOptio
 		return err
 	}
 
-	if err := c.WaitUntilPodBySelectorExist("eirini-core", "name=eirini-api", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Eirini api deployment to exist")
-	}
-	if err := c.WaitForPodBySelectorRunning("eirini-core", "name=eirini-api", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Eirini api deployment to come up")
-	}
-	if err := c.WaitUntilPodBySelectorExist("eirini-core", "name=eirini-metrics", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Eirini metrics deployment to exist")
-	}
-	if err := c.WaitForPodBySelectorRunning("eirini-core", "name=eirini-metrics", k.Timeout); err != nil {
-		return errors.Wrap(err, "failed waiting Eirini metrics deployment to come up")
+	for _, podname := range []string{
+		"eirini-api",
+		"eirini-metrics",
+	} {
+		if err := c.WaitUntilPodBySelectorExist("eirini-core", "name="+podname, k.Timeout); err != nil {
+			return errors.Wrap(err, "failed waiting Eirini "+podname+" deployment to exist")
+		}
+		if err := c.WaitForPodBySelectorRunning("eirini-core", "name="+podname, k.Timeout); err != nil {
+			return errors.Wrap(err, "failed waiting Eirini "+podname+" deployment to come up")
+		}
 	}
 
 	emoji.Println(":heavy_check_mark: Eirini deployed")

--- a/cli/deployments/traefik.go
+++ b/cli/deployments/traefik.go
@@ -70,7 +70,10 @@ func (k Traefik) apply(c kubernetes.Cluster, options kubernetes.InstallationOpti
 		return errors.Wrap(err, fmt.Sprintf("Failed installing Traefik: %s\n", out))
 	}
 
-	if err := c.WaitForPodBySelectorRunning(traefikDeploymentID, "", k.Timeout); err != nil {
+	if err := c.WaitUntilPodBySelectorExist(traefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
+		return errors.Wrap(err, "failed waiting Traefik Ingress deployment to exist")
+	}
+	if err := c.WaitForPodBySelectorRunning(traefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
 		return errors.Wrap(err, "failed waiting Traefik Ingress deployment to come up")
 	}
 


### PR DESCRIPTION
The same race seen in the eirini deployment and fixed with PR #46  is also present in `gitea`, `quarks`, and `traefik`. The same fix has been applied now (wait for pod existence first before waiting for it to be running).

All deployments were changed to use an explicit list of pods to check and wait for. They were also changed to use a loop over the pod names, if the set of pods contained more than one entry.

:warning: Attention: The `tekton` deployment code is different enough to be unsure if it has similar races or not, and the above fix cannot be applied as is. Some trials with pushing an app after install ran into `el-listener` errors about not finding tekton-related things (Our `triggertemplate`, and `triggerpipeline`, respectively) while these looked to be present when checking the cluster. Simply waiting a few minutes between `install` and `push` seemed to resolve these issues, indicating that there is indeed some kind of race present, albeit not exactly the same handled here, as it does not seem to involve pods.

Fixes #34 