### PR TITLE
[feat] Improve staging logs.

### DIFF
--- a/cli/kubernetes/tailer/setup.go
+++ b/cli/kubernetes/tailer/setup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/suse/carrier/cli/kubernetes"
+	"github.com/suse/carrier/cli/paas/ui"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -36,7 +37,7 @@ type Config struct {
 //   - For log entries `Exclude` is applied before `Include`.
 
 // Run starts the log watching
-func Run(ctx context.Context, config *Config, cluster *kubernetes.Cluster) error {
+func Run(ui *ui.UI, ctx context.Context, config *Config, cluster *kubernetes.Cluster) error {
 	var namespace string
 
 	if config.AllNamespaces {
@@ -59,7 +60,7 @@ func Run(ctx context.Context, config *Config, cluster *kubernetes.Cluster) error
 				continue
 			}
 
-			tail := NewTail(p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{
+			tail := NewTail(ui, p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{
 				Timestamps:   config.Timestamps,
 				SinceSeconds: int64(config.Since.Seconds()),
 				Exclude:      config.Exclude,

--- a/cli/kubernetes/tailer/setup.go
+++ b/cli/kubernetes/tailer/setup.go
@@ -13,20 +13,27 @@ import (
 
 // Config contains the config for stern
 type Config struct {
-	Namespace             string
-	PodQuery              *regexp.Regexp
-	Timestamps            bool
-	ContainerQuery        *regexp.Regexp
-	ExcludeContainerQuery *regexp.Regexp
-	ContainerState        ContainerState
-	Exclude               []*regexp.Regexp
-	Include               []*regexp.Regexp
-	Since                 time.Duration
+	Namespace             string           // Name of the namespace to monitor
+	PodQuery              *regexp.Regexp   // Limit monitoring to pods matching the RE
+	Timestamps            bool             // Print timestamps before each entry.
+	ContainerQuery        *regexp.Regexp   // Limit monitoring to containers matching the RE
+	ExcludeContainerQuery *regexp.Regexp   // Exclusion list if the above alone is not enough.
+	ContainerState        ContainerState   // Limit monitoring to containers in this state.
+	Exclude               []*regexp.Regexp // If specified suppress all log entries matching the RE
+	Include               []*regexp.Regexp // If specified show only log entries matching this RE
+	Since                 time.Duration    // Show only log entries younger than the duration.
 	AllNamespaces         bool
 	LabelSelector         labels.Selector
 	TailLines             *int64
-	Template              *template.Template
+	Template              *template.Template // Template to apply to log entries for formatting
 }
+
+// Notes on the above:
+//   - For containers `ContainerQuery` is applied before
+//     `ExcludeContainerQuery`. IOW use `CQ` to get an initial list of
+//     containers and then use `ECQ` to pare that down further.
+//
+//   - For log entries `Exclude` is applied before `Include`.
 
 // Run starts the log watching
 func Run(ctx context.Context, config *Config, cluster *kubernetes.Cluster) error {

--- a/cli/kubernetes/tailer/tailer.go
+++ b/cli/kubernetes/tailer/tailer.go
@@ -91,11 +91,11 @@ func (t *Tail) Start(ctx context.Context, i v1.PodInterface) {
 		c := t.containerColor.SprintFunc()
 		var m string
 		if t.Options.Namespace {
-			m = fmt.Sprintf("%s %s %s › %s", g("Now tracking"), p(t.Namespace), p(t.PodName), c(t.ContainerName))
+			m = fmt.Sprintf("%s %s %s › %s ", g("Now tracking"), p(t.Namespace), p(t.PodName), c(t.ContainerName))
 		} else {
-			m = fmt.Sprintf("%s %s › %s", g("Now tracking"), p(t.PodName), c(t.ContainerName))
+			m = fmt.Sprintf("%s %s › %s ", g("Now tracking"), p(t.PodName), c(t.ContainerName))
 		}
-		t.ui.ProgressNote().Msg(m)
+		t.ui.ProgressNote().KeepLine().Msg(m)
 
 		req := i.GetLogs(t.PodName, &corev1.PodLogOptions{
 			Follow:       true,
@@ -128,7 +128,7 @@ func (t *Tail) Start(ctx context.Context, i v1.PodInterface) {
 				return
 			}
 
-			str := string(line)
+			str := strings.TrimRight(string(line), "\r\n\t ")
 
 			for _, rex := range t.Options.Exclude {
 				if rex.MatchString(str) {
@@ -189,7 +189,7 @@ func (t *Tail) Print(msg string) {
 		os.Stderr.WriteString(fmt.Sprintf("expanding template failed: %s", err))
 		return
 	}
-	t.ui.ProgressNote().Msg(result.String())
+	t.ui.ProgressNote().KeepLine().Msg(result.String() + " ")
 }
 
 // Log is the object which will be used together with the template to generate

--- a/cli/kubernetes/tailer/templates.go
+++ b/cli/kubernetes/tailer/templates.go
@@ -11,7 +11,7 @@ import (
 // DefaultSingleNamespaceTemplate returns a printing template used when
 // printing with colors and watching resources in a single namespace
 func DefaultSingleNamespaceTemplate() *template.Template {
-	t := "{{color .PodColor .PodName}} {{color .ContainerColor .ContainerName}} {{.Message}}"
+	t := "{{color .PodColor .Origin}} {{color .ContainerColor .ContainerName}} {{.Message}}"
 
 	funs := map[string]interface{}{
 		"json": func(in interface{}) (string, error) {

--- a/cli/paas/client.go
+++ b/cli/paas/client.go
@@ -489,7 +489,7 @@ func (c *CarrierClient) logs(name string) (context.CancelFunc, error) {
 
 	// TODO: improve the way we look for pods, use selectors
 	// and watch staging as well
-	err := tailer.Run(ctx, &tailer.Config{
+	err := tailer.Run(c.ui, ctx, &tailer.Config{
 		ContainerQuery:        regexp.MustCompile(".*"),
 		ExcludeContainerQuery: nil,
 		ContainerState:        "running",

--- a/cli/paas/client.go
+++ b/cli/paas/client.go
@@ -496,7 +496,7 @@ func (c *CarrierClient) logs(name string) (context.CancelFunc, error) {
 		Exclude:               nil,
 		Include:               nil,
 		Timestamps:            false,
-		Since:                 172800000000000, //48hr
+		Since:                 48 * time.Hour,
 		AllNamespaces:         false,
 		LabelSelector:         labels.Everything(),
 		TailLines:             nil,

--- a/cli/paas/client.go
+++ b/cli/paas/client.go
@@ -503,7 +503,7 @@ func (c *CarrierClient) logs(name string) (context.CancelFunc, error) {
 		Template:              tailer.DefaultSingleNamespaceTemplate(),
 
 		Namespace: "eirini-workloads",
-		PodQuery:  regexp.MustCompile(fmt.Sprintf(".*%s.*", name)),
+		PodQuery:  regexp.MustCompile(fmt.Sprintf(".*-%s-.*", name)),
 	}, c.kubeClient)
 	if err != nil {
 		return cancelFunc, errors.Wrap(err, "failed to start log tail")

--- a/cli/paas/ui/dot_progress.go
+++ b/cli/paas/ui/dot_progress.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kyokomi/emoji"
+	"github.com/fatih/color"
 )
 
 // This file implements the DotProgress form of the Progress
@@ -32,7 +32,7 @@ func NewDotProgress(ui *UI, message string) *DotProgress {
 		active:   false,
 		stopChan: make(chan struct{}, 1),
 	}
-	p.ui.Raw(message)
+	p.ui.ProgressNote().KeepLine().Msg(message)
 	p.Start()
 	return p
 }
@@ -57,7 +57,10 @@ func (p *DotProgress) Start() {
 					p.mu.Unlock()
 					return
 				}
-				p.ui.Raw(".")
+				p.ui.Normal().
+					Compact().
+					KeepLine().
+					Msg(color.MagentaString("."))
 				delay := p.Delay
 				p.mu.Unlock()
 				time.Sleep(delay)
@@ -71,7 +74,7 @@ func (p *DotProgress) Stop() {
 	defer p.mu.Unlock()
 	if p.active {
 		p.active = false
-		p.ui.Raw("\n")
+		p.ui.Normal().Compact().Msg("")
 		p.stopChan <- struct{}{}
 	}
 }
@@ -87,10 +90,10 @@ func (p *DotProgress) ChangeMessagef(message string, a ...interface{}) {
 func (p *DotProgress) ChangeMessage(message string) {
 	message = mfinal(message)
 	p.Stop()
-	p.ui.Raw(message)
+	p.ui.ProgressNote().KeepLine().Msg(message)
 	p.Start()
 }
 
 func mfinal(message string) string {
-	return emoji.Sprint(":three-thirty: " + message + " ")
+	return message + " "
 }


### PR DESCRIPTION
Fixes #75.

Modified the staging logs to show an `Origin` (staging or app) for the log entries coming out of the tailers.
Dropped the full pod name in favor of it. Kept the container name.

Note: There are still log lines not captured by this.
These log lines have a green-colored leading `+` character.
At the moment it is unclear where these are coming from.

@viovanov do you have an idea ?

Example gathered by disabling tailer and progress indicator:
```
+ staging-pipeline-run-sample2-8tzkq-clone-cfv9t-pod-ndszb › step-git-source-source-repo-pghwv
+ staging-pipeline-run-sample2-8tzkq-clone-cfv9t-pod-ndszb › step-stage
+ staging-pipeline-run-sample2-8tzkq-stage-dt4jf-pod-hmxc5 › step-create
+ staging-pipeline-run-sample2-8tzkq-stage-dt4jf-pod-hmxc5 › step-create-dir-image-g6ckt
+ staging-pipeline-run-sample2-8tzkq-stage-dt4jf-pod-hmxc5 › step-image-digest-exporter-qbhwm
+ staging-pipeline-run-sample2-8tzkq-stage-dt4jf-pod-hmxc5 › step-prepare
+ staging-pipeline-run-sample2-8tzkq-run-wvqrr-pod-7lz55 › step-run
```

Just after the regular user message of 
```
🕞  Creating cloudfoundry.org/guid=sample2 in eirini-workloads
```

I wonder if that is some output from a `kubectl` command we are running here.

Ok, these lines are the stderr of something ... Looking at the uses of `helper.RunProc` (which allows stderr to be seen in the terminal) most of these are in the deployments, so do not apply to `Push`. The lone other is used in the `Kubectl` helper.

... Nope. Dead End. Switching to `RunProcNoErr` in `Kubectl` does not suppress these lines. Need a new hypothesis for the origin.

Completely disabling `logs()` prevents these lines.

... Found it

```
	if t.Options.Namespace {
		fmt.Fprintf(os.Stderr, "%s %s %s › %s\n", g("+"), p(t.Namespace), p(t.PodName), c(t.ContainerName))
	} else {
		fmt.Fprintf(os.Stderr, "%s %s › %s\n", g("+"), p(t.PodName), c(t.ContainerName))
	}
```

It is the part of the tailer telling us when it finds a new pod to track.
Not sure if we need that, actually.
