### PR TITLE
[Fix] Ensure good organization for several commands, and after install

### DIFF
--- a/cli/cmd/internal/client/install.go
+++ b/cli/cmd/internal/client/install.go
@@ -18,6 +18,10 @@ var NeededOptions = kubernetes.InstallationOptions{
 	},
 }
 
+const (
+	DefaultOrganization = "workspace"
+)
+
 var CmdInstall = &cobra.Command{
 	Use:           "install",
 	Short:         "install Carrier in your configured kubernetes cluster",
@@ -73,9 +77,24 @@ func Install(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(err, "error initializing cli")
 	}
 
-	err = carrier_client.CreateOrg("workspace")
+	// Post Installation Tasks:
+	// - Create and target a default organization, so that the
+	//   user can immediately begin to push applications.
+	//
+	// Dev Note: The targeting is done to ensure that a carrier
+	// config left over from a previous installation will contain
+	// a valid organization. Without it may contain the name of a
+	// now invalid organization from said previous install. This
+	// then breaks push and other commands in non-obvious ways.
+
+	err = carrier_client.CreateOrg(DefaultOrganization)
 	if err != nil {
 		return errors.Wrap(err, "error creating org")
+	}
+
+	err = carrier_client.Target(DefaultOrganization)
+	if err != nil {
+		return errors.Wrap(err, "failed to set target")
 	}
 
 	return nil

--- a/cli/paas/client.go
+++ b/cli/paas/client.go
@@ -247,7 +247,7 @@ func (c *CarrierClient) Push(app string, path string) error {
 	}
 	defer stopFunc()
 
-	err = c.waitForApp(c.ui, app)
+	err = c.waitForApp(app)
 	if err != nil {
 		return errors.Wrap(err, "waiting for app failed")
 	}
@@ -512,17 +512,17 @@ func (c *CarrierClient) logs(name string) (context.CancelFunc, error) {
 	return cancelFunc, nil
 }
 
-func (c *CarrierClient) waitForApp(ui *ui.UI, name string) error {
+func (c *CarrierClient) waitForApp(name string) error {
 	c.ui.ProgressNote().Msg("Creating application resources")
 	err := c.kubeClient.WaitUntilPodBySelectorExist(
-		ui, c.config.EiriniWorkloadsNamespace,
+		c.ui, c.config.EiriniWorkloadsNamespace,
 		fmt.Sprintf("cloudfoundry.org/guid=%s", name),
 		300)
 
 	c.ui.ProgressNote().Msg("Starting application")
 
 	err = c.kubeClient.WaitForPodBySelectorRunning(
-		ui, c.config.EiriniWorkloadsNamespace,
+		c.ui, c.config.EiriniWorkloadsNamespace,
 		fmt.Sprintf("cloudfoundry.org/guid=%s", name),
 		300)
 


### PR DESCRIPTION
Fixes #76.

Commands `push`, `apps`, and `target` now properly validate the organization, either argument, or from the config.
Command `install` now targets the newly created default workspace, squashing any bogus org information in the config left over from a previous installation.
