### PR TITLE
[fix] Changed carrier to use the `--kubeconfig`/`-c` cli options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ tools-versions:
 version:
 	@./scripts/version.sh
 
+help:
+	@$(MAKE) -C cli help
+
 build:
 	@$(MAKE) -C cli build
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -60,3 +60,6 @@ update_tekton:
 
 embed_files:
 	statik -f -src=./embedded-files
+
+help:
+	( echo _ _ ___ _____ ________ Overview ; carrier help ; for cmd in apps completion create-org delete help info install orgs push target uninstall ; do echo ; echo _ _ ___ _____ ________ Command $$cmd ; carrier $$cmd --help ; done ; echo ) | tee ../HELP

--- a/cli/cmd/internal/client/apps.go
+++ b/cli/cmd/internal/client/apps.go
@@ -12,7 +12,7 @@ var ()
 // CmdApps implements the carrier app command
 var CmdApps = &cobra.Command{
 	Use:   "apps",
-	Short: "Lists all apps",
+	Short: "Lists all applications",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, cleanup, err := paas.NewCarrierClient(cmd.Flags(), nil)

--- a/cli/cmd/internal/client/apps.go
+++ b/cli/cmd/internal/client/apps.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -35,13 +34,4 @@ var CmdApps = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func init() {
-	pf := CmdApps.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdApps, argToEnv)
 }

--- a/cli/cmd/internal/client/create_org.go
+++ b/cli/cmd/internal/client/create_org.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -35,13 +34,4 @@ var CmdCreateOrg = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func init() {
-	pf := CmdCreateOrg.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdCreateOrg, argToEnv)
 }

--- a/cli/cmd/internal/client/create_org.go
+++ b/cli/cmd/internal/client/create_org.go
@@ -12,7 +12,7 @@ var ()
 // CmdCreateOrg implements the carrier orgs command
 var CmdCreateOrg = &cobra.Command{
 	Use:   "create-org NAME",
-	Short: "Creates an org",
+	Short: "Creates an organization",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, cleanup, err := paas.NewCarrierClient(cmd.Flags(), nil)

--- a/cli/cmd/internal/client/delete.go
+++ b/cli/cmd/internal/client/delete.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -50,13 +49,4 @@ var CmdDeleteApp = &cobra.Command{
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
-}
-
-func init() {
-	pf := CmdDeleteApp.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdDeleteApp, argToEnv)
 }

--- a/cli/cmd/internal/client/delete.go
+++ b/cli/cmd/internal/client/delete.go
@@ -12,7 +12,7 @@ var ()
 // CmdDeleteApp implements the carrier delete command
 var CmdDeleteApp = &cobra.Command{
 	Use:   "delete NAME",
-	Short: "Deletes an app",
+	Short: "Deletes an application",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, cleanup, err := paas.NewCarrierClient(cmd.Flags(), nil)

--- a/cli/cmd/internal/client/info.go
+++ b/cli/cmd/internal/client/info.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -35,13 +34,4 @@ var CmdInfo = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func init() {
-	pf := CmdInfo.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdInfo, argToEnv)
 }

--- a/cli/cmd/internal/client/install.go
+++ b/cli/cmd/internal/client/install.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/kubernetes"
@@ -33,15 +32,8 @@ var CmdInstall = &cobra.Command{
 }
 
 func init() {
-	pf := CmdInstall.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdInstall, argToEnv)
-
-	CmdInstall.Flags().BoolP("verbose", "v", true, "Wether to print logs to stdout")
-	CmdInstall.Flags().BoolP("interactive", "i", false, "Whether to ask the user or not")
+	CmdInstall.Flags().BoolP("verbose", "v", true, "Whether to print logs (stdout) or not")
+	CmdInstall.Flags().BoolP("interactive", "i", false, "Whether to ask the user or not (default not)")
 
 	NeededOptions.AsCobraFlagsFor(CmdInstall)
 }

--- a/cli/cmd/internal/client/install.go
+++ b/cli/cmd/internal/client/install.go
@@ -32,7 +32,7 @@ var CmdInstall = &cobra.Command{
 }
 
 func init() {
-	CmdInstall.Flags().BoolP("verbose", "v", true, "Whether to print logs (stdout) or not")
+	CmdInstall.Flags().BoolP("verbose", "v", true, "Print more detailed messages")
 	CmdInstall.Flags().BoolP("interactive", "i", false, "Whether to ask the user or not (default not)")
 
 	NeededOptions.AsCobraFlagsFor(CmdInstall)

--- a/cli/cmd/internal/client/orgs.go
+++ b/cli/cmd/internal/client/orgs.go
@@ -12,7 +12,7 @@ var ()
 // CmdOrgs implements the carrier orgs command
 var CmdOrgs = &cobra.Command{
 	Use:   "orgs",
-	Short: "Lists all orgs",
+	Short: "Lists all organizations",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, cleanup, err := paas.NewCarrierClient(cmd.Flags(), nil)
 		defer func() {

--- a/cli/cmd/internal/client/orgs.go
+++ b/cli/cmd/internal/client/orgs.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -34,13 +33,4 @@ var CmdOrgs = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func init() {
-	pf := CmdOrgs.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdOrgs, argToEnv)
 }

--- a/cli/cmd/internal/client/push.go
+++ b/cli/cmd/internal/client/push.go
@@ -12,7 +12,7 @@ var ()
 // CmdPush implements the carrier orgs command
 var CmdPush = &cobra.Command{
 	Use:   "push NAME",
-	Short: "Push an app from the current working directory",
+	Short: "Push an application from the current working directory",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client, cleanup, err := paas.NewCarrierClient(cmd.Flags(), nil)

--- a/cli/cmd/internal/client/push.go
+++ b/cli/cmd/internal/client/push.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -36,13 +35,4 @@ var CmdPush = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func init() {
-	pf := CmdPush.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdPush, argToEnv)
 }

--- a/cli/cmd/internal/client/target.go
+++ b/cli/cmd/internal/client/target.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -55,13 +54,4 @@ var CmdTarget = &cobra.Command{
 
 		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
-}
-
-func init() {
-	pf := CmdTarget.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdTarget, argToEnv)
 }

--- a/cli/cmd/internal/client/uninstall.go
+++ b/cli/cmd/internal/client/uninstall.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/paas"
@@ -15,15 +14,6 @@ var CmdUninstall = &cobra.Command{
 	RunE:          Uninstall,
 	SilenceErrors: true,
 	SilenceUsage:  true,
-}
-
-func init() {
-	pf := CmdUninstall.PersistentFlags()
-
-	argToEnv := map[string]string{}
-
-	cmd.KubeConfigFlags(pf, argToEnv)
-	cmd.AddEnvToUsage(CmdUninstall, argToEnv)
 }
 
 // Uninstall command removes carrier from a configured cluster

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyokomi/emoji"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/cmd/internal/client"
+	"github.com/suse/carrier/cli/kubernetes/config"
 )
 
 const (
@@ -34,6 +35,10 @@ func Execute() {
 	}
 
 	rootCmd.PersistentFlags().StringVarP(&flagConfigFile, "config-file", "", "", "set path of configuration file")
+
+	argToEnv := map[string]string{}
+	config.KubeConfigFlags(rootCmd.PersistentFlags(), argToEnv)
+	config.AddEnvToUsage(rootCmd, argToEnv)
 
 	rootCmd.AddCommand(CmdCompletion)
 	rootCmd.AddCommand(client.CmdInstall)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -12,7 +12,6 @@ replace (
 
 require (
 	code.cloudfoundry.org/eirini v0.0.0-20201118000750-3dcf72f6ed2f
-	code.cloudfoundry.org/quarks-utils v0.0.1
 	code.gitea.io/sdk/gitea v0.13.2
 	github.com/briandowns/spinner v1.12.0
 	github.com/codeskyblue/kexec v0.0.0-20180119015717-5a4bed90d99a

--- a/cli/kubernetes/config/argtoenv.go
+++ b/cli/kubernetes/config/argtoenv.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// AddEnvToUsage adds env variables to help
+func AddEnvToUsage(cmd *cobra.Command, argToEnv map[string]string) {
+	flagSet := make(map[string]bool)
+
+	for arg, env := range argToEnv {
+		viper.BindEnv(arg, env)
+		flag := cmd.Flag(arg)
+
+		if flag != nil {
+			flagSet[flag.Name] = true
+			// add environment variable to the description
+			flag.Usage = fmt.Sprintf("(%s) %s", env, flag.Usage)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #89.

:fireworks: It was a nice surprise that just the removal of the replicated setup of `--kubeconfig` in all the individual commands, and replacing it with a single centralized root level setup was enough to also fix the issue. Seems that the config code expected such a root level flag, and simply ignored it as `not set` when it was not present.
