### PR TITLE
Remove HasLoadBalancer() func & Check ns ownership before uninstallation

### DIFF
--- a/cmd/internal/client/uninstall.go
+++ b/cmd/internal/client/uninstall.go
@@ -25,7 +25,7 @@ func Uninstall(cmd *cobra.Command, args []string) error {
 
 	err = installClient.Uninstall(cmd)
 	if err != nil {
-		return errors.Wrap(err, "error uninstalling Carrier")
+		return err
 	}
 
 	return nil

--- a/deployments/traefik.go
+++ b/deployments/traefik.go
@@ -102,14 +102,6 @@ func (k Traefik) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Inst
 	// Setup Traefik helm values
 	var helmArgs []string
 
-	// Setup ExternalIPs for platforms where there is no loadbalancer
-	platform := c.GetPlatform()
-	if !platform.HasLoadBalancer() {
-		for i, ip := range platform.ExternalIPs() {
-			helmArgs = append(helmArgs, "--set service.externalIPs["+strconv.Itoa(i)+"]="+ip)
-		}
-	}
-
 	// Disable sending anonymous usage statistics
 	// https://github.com/traefik/traefik-helm-chart/blob/v9.11.0/traefik/values.yaml#L170
 	// Overwrite globalArguments until https://github.com/traefik/traefik-helm-chart/issues/357 is fixed
@@ -130,10 +122,6 @@ func (k Traefik) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Inst
 	}
 	if err := c.WaitForPodBySelectorRunning(ui, TraefikDeploymentID, "app.kubernetes.io/name=traefik", k.Timeout); err != nil {
 		return errors.Wrap(err, "failed waiting Traefik Ingress deployment to come up")
-	}
-
-	if platform.HasLoadBalancer() {
-		// TODO: Wait until an IP address is assigned
 	}
 
 	ui.Success().Msg("Traefik Ingress deployed")

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,77 @@
+# Installation
+
+- [Installation](#installation)
+  - [Provision of External IP for LoadBalancer service type in Kubernetes](#provision-of-external-ip-for-loadbalancer-service-type-in-kubernetes)
+    - [K3s/K3d](#k3sk3d)
+    - [Minikube](#minikube)
+    - [Kind](#kind)
+    - [MircoK8s](#mircok8s)
+
+## Provision of External IP for LoadBalancer service type in Kubernetes
+
+Local kubernetes platforms do not have the ability to provide external IP address when you create a kubernetes service with `LoadBalancer` service type. The following steps will enable this ability for different local kubernetes platforms. Follow these steps before installing carrier.
+
+### K3s/K3d
+
+* Provision of LoadBalancer IP is enabled by default in K3s/K3d.
+
+### Minikube
+
+* Install and configure MetalLB
+```
+minikube addons enable metallb
+
+MINIKUBE_IP=($(minikube ip))
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - ${MINIKUBE_IP}/28
+EOF
+```
+
+### Kind 
+
+* Install JQ from https://stedolan.github.io/jq/download/
+
+* Install and configure MetalLB 
+```
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+
+SUBNET_IP=`docker network inspect kind | jq -r '.[0].IPAM.Config[0].Subnet'`
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - ${SUBNET_IP}/28
+EOF
+```
+
+### MircoK8s
+
+* Install and configure MetalLB
+```
+INTERFACE=`ip route | grep default | awk '{print $5}'`
+IP=`ifconfig $INTERFACE | sed -n '2 p' | awk '{print $2}'`
+microk8s enable metallb:${IP}/16
+```
+
+

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -19,7 +19,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -405,6 +405,36 @@ func (c *Cluster) LabelNamespace(namespace, labelKey, labelValue string) error {
 	return nil
 }
 
+// NamespaceExistsAndOwned checks if the namespace exists
+// and is created by carrier or not.
+func (c *Cluster) NamespaceExistsAndOwned(namespaceName string) (bool, error) {
+	exists, err := c.NamespaceExists(namespaceName)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+
+	owned, err := c.NamespaceLabelExists(namespaceName, CarrierDeploymentLabelKey)
+	if err != nil {
+		return false, err
+	}
+	return owned, nil
+}
+
+// NamespaceExists checks if a namespace exists or not
+func (c *Cluster) NamespaceExists(namespaceName string) (bool, error) {
+	_, err := c.Kubectl.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // NamespaceLabelExists checks if a specific label exits on the namespace
 func (c *Cluster) NamespaceLabelExists(namespaceName, labelKey string) (bool, error) {
 	namespace, err := c.Kubectl.CoreV1().Namespaces().Get(context.Background(), namespaceName, metav1.GetOptions{})
@@ -419,26 +449,11 @@ func (c *Cluster) NamespaceLabelExists(namespaceName, labelKey string) (bool, er
 	return false, nil
 }
 
-// DeleteNamespaceIfOwned deletes the namepace if it exists and
-// has a carrier label otherwise returns the warning as a string
-func (c *Cluster) DeleteNamespaceIfOwned(namespace string) (string, error) {
-	owned, err := c.NamespaceLabelExists(namespace, CarrierDeploymentLabelKey)
+// DeleteNamespace deletes the namepace
+func (c *Cluster) DeleteNamespace(namespace string) error {
+	err := c.Kubectl.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
 	if err != nil {
-		if kubeerrors.IsNotFound(err) {
-			return fmt.Sprintf("%s namespace not found, skipping.\n", namespace), nil
-		}
-		return "", err
+		return err
 	}
-
-	if owned {
-		err = c.Kubectl.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
-		if err != nil {
-			return "", err
-		}
-
-	} else {
-		return fmt.Sprintf("%s namespace found but was not created by Carrier, skipping.\n", namespace), nil
-	}
-
-	return "", nil
+	return nil
 }

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -45,7 +45,6 @@ var (
 
 type Platform interface {
 	Detect(*kubernetes.Clientset) bool
-	HasLoadBalancer() bool
 	Describe() string
 	String() string
 	Load(*kubernetes.Clientset) error

--- a/kubernetes/platform/generic/generic.go
+++ b/kubernetes/platform/generic/generic.go
@@ -12,10 +12,6 @@ type Generic struct {
 	InternalIPs, ExternalIP []string
 }
 
-func (k *Generic) HasLoadBalancer() bool {
-	return true
-}
-
 func (k *Generic) Describe() string {
 	return emoji.Sprintf(":anchor:Detected kubernetes platform: %s\n:earth_americas:ExternalIPs: %s\n:curly_loop:InternalIPs: %s", k.String(), k.ExternalIPs(), k.InternalIPs)
 }

--- a/kubernetes/platform/k3s/k3s.go
+++ b/kubernetes/platform/k3s/k3s.go
@@ -15,10 +15,6 @@ type k3s struct {
 	generic.Generic
 }
 
-func (k *k3s) HasLoadBalancer() bool {
-	return true
-}
-
 func (k *k3s) Describe() string {
 	return emoji.Sprintf(":anchor:Detected kubernetes platform: %s\n:earth_americas:ExternalIPs: %s\n:curly_loop:InternalIPs: %s", k.String(), k.ExternalIPs(), k.InternalIPs)
 }

--- a/kubernetes/platform/kind/kind.go
+++ b/kubernetes/platform/kind/kind.go
@@ -15,10 +15,6 @@ type kind struct {
 	generic.Generic
 }
 
-func (k *kind) HasLoadBalancer() bool {
-	return false
-}
-
 func (k *kind) Describe() string {
 	return emoji.Sprintf(":anchor:Detected kubernetes platform: %s\n:earth_americas:ExternalIPs: %s\n:curly_loop:InternalIPs: %s", k.String(), k.ExternalIPs(), k.InternalIPs)
 }

--- a/kubernetes/platform/minikube/minikube.go
+++ b/kubernetes/platform/minikube/minikube.go
@@ -15,10 +15,6 @@ type Minikube struct {
 	generic.Generic
 }
 
-func (m *Minikube) HasLoadBalancer() bool {
-	return false
-}
-
 // Describe returns information about the platform.
 func (m *Minikube) Describe() string {
 	return emoji.Sprintf(":anchor:Detected kubernetes platform: %s\n:earth_americas:ExternalIPs: %s\n:curly_loop:InternalIPs: %s", m.String(), m.ExternalIPs(), m.InternalIPs)

--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/suse/carrier/cli/deployments"
+	"github.com/suse/carrier/cli/helpers"
 	"github.com/suse/carrier/cli/kubernetes"
 	"github.com/suse/carrier/cli/paas/config"
 	"github.com/suse/carrier/cli/paas/ui"
@@ -176,44 +178,45 @@ func (c *InstallClient) showInstallConfiguration(opts *kubernetes.InstallationOp
 func (c *InstallClient) fillInMissingSystemDomain(domain *kubernetes.InstallationOption) error {
 	if domain.Value.(string) == "" {
 		ip := ""
-		if !c.kubeClient.GetPlatform().HasLoadBalancer() {
-			ips := c.kubeClient.GetPlatform().ExternalIPs()
-			if len(ips) > 0 {
-				ip = ips[0]
+		s := c.ui.Progressf("Waiting for LoadBalancer IP on traefik service.")
+		defer s.Stop()
+		err := helpers.RunToSuccessWithTimeout(
+			func() error {
+				return c.fetchIP(&ip)
+			}, time.Duration(2)*time.Minute, 3*time.Second)
+		if err != nil {
+			if strings.Contains(err.Error(), "Timed out after") {
+				return errors.New("Timed out waiting for LoadBalancer IP on traefik service.\n" +
+					"Ensure your kubernetes platform has the ability to provision LoadBalancer IP address.\n\n" +
+					"Follow these steps to enable this ability\n" +
+					"https://github.com/SUSE/carrier/blob/main/docs/install.md")
 			}
-		} else {
-			s := c.ui.Progressf("Waiting for LoadBalancer IP on traefik service.")
-			defer s.Stop()
-			timeout := time.After(2 * time.Minute)
-			ticker := time.Tick(1 * time.Second)
-		Exit:
-			for {
-				select {
-				case <-timeout:
-					break Exit
-				case <-ticker:
-					serviceList, err := c.kubeClient.Kubectl.CoreV1().Services("").List(context.Background(), metav1.ListOptions{
-						FieldSelector: "metadata.name=traefik",
-					})
-					if len(serviceList.Items) == 0 {
-						return errors.New("Couldn't find the traefik service")
-					}
-					if err != nil {
-						return err
-					}
-					ingress := serviceList.Items[0].Status.LoadBalancer.Ingress
-					if len(ingress) > 0 {
-						ip = ingress[0].IP
-						break Exit
-					}
-				}
-			}
+			return err
 		}
 
 		if ip != "" {
 			domain.Value = fmt.Sprintf("%s.omg.howdoi.website", ip)
 		}
 	}
+
+	return nil
+}
+
+func (c *InstallClient) fetchIP(ip *string) error {
+	serviceList, err := c.kubeClient.Kubectl.CoreV1().Services("").List(context.Background(), metav1.ListOptions{
+		FieldSelector: "metadata.name=traefik",
+	})
+	if len(serviceList.Items) == 0 {
+		return errors.New("couldn't find the traefik service")
+	}
+	if err != nil {
+		return err
+	}
+	ingress := serviceList.Items[0].Status.LoadBalancer.Ingress
+	if len(ingress) <= 0 {
+		return errors.New("ingress list is empty in traefik service")
+	}
+	*ip = ingress[0].IP
 
 	return nil
 }

--- a/paas/install_client.go
+++ b/paas/install_client.go
@@ -43,25 +43,25 @@ func (c *InstallClient) Install(cmd *cobra.Command, options *kubernetes.Installa
 	details.Info("process cli options")
 	options, err = options.Populate(kubernetes.NewCLIOptionsReader(cmd))
 	if err != nil {
-		return errors.Wrap(err, "Couldn't install carrier")
+		return err
 	}
 
 	interactive, err := cmd.Flags().GetBool("interactive")
 	if err != nil {
-		return errors.Wrap(err, "Couldn't install carrier")
+		return err
 	}
 
 	if interactive {
 		details.Info("query user for options")
 		options, err = options.Populate(kubernetes.NewInteractiveOptionsReader(os.Stdout, os.Stdin))
 		if err != nil {
-			return errors.Wrap(err, "Couldn't install carrier")
+			return err
 		}
 	} else {
 		details.Info("fill defaults into options")
 		options, err = options.Populate(kubernetes.NewDefaultOptionsReader())
 		if err != nil {
-			return errors.Wrap(err, "Couldn't install carrier")
+			return err
 		}
 	}
 
@@ -85,16 +85,16 @@ func (c *InstallClient) Install(cmd *cobra.Command, options *kubernetes.Installa
 	// Try to give a omg.howdoi.website domain if the user didn't specify one
 	domain, err := options.GetOpt("system_domain", "")
 	if err != nil {
-		return errors.Wrap(err, "Couldn't install carrier")
+		return err
 	}
 
 	details.Info("ensure system-domain")
 	err = c.fillInMissingSystemDomain(domain)
 	if err != nil {
-		return errors.Wrap(err, "Couldn't install carrier")
+		return err
 	}
 	if domain.Value.(string) == "" {
-		return errors.New("You didn't provide a system_domain and we were unable to setup a omg.howdoi.website domain (couldn't find and ExternalIP)")
+		return errors.New("You didn't provide a system_domain and we were unable to setup a omg.howdoi.website domain (couldn't find an ExternalIP)")
 	}
 
 	c.ui.Success().Msg("Created system_domain: " + domain.Value.(string))


### PR DESCRIPTION
Fixes #83 

This PR does the following things

It removes HasLoadBalancer() concept as we cannot deterministically find if the underlying platform has the ability to provision IP address for `LoadBalancer` service type. Now, carrier will install traefik and wait for the the `LoadBalacner` IP. If it is not provisioned by the kube, then carrier will time out and point to a documentation which gives steps to enable this ability in local kubes.

This PR also checks ownership of the namespace before uninstalling components.



