### PR TITLE
Cleanup non needed quarks and Eirini components

### DIFF
--- a/cli/deployments/eirini.go
+++ b/cli/deployments/eirini.go
@@ -69,7 +69,12 @@ func (k Eirini) Delete(c *kubernetes.Cluster, ui *ui.UI) error {
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(releaseDir)
+	defer func() {
+		err := os.RemoveAll(releaseDir)
+		if err != nil {
+			ui.Exclamation().Msg(err.Error())
+		}
+	}()
 
 	for _, component := range []string{
 		"core/lrp-crd.yml",
@@ -145,7 +150,12 @@ func (k Eirini) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Insta
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(releaseDir)
+	defer func() {
+		err := os.RemoveAll(releaseDir)
+		if err != nil {
+			ui.Exclamation().Msg(err.Error())
+		}
+	}()
 
 	message := "Creating Eirini namespace for core components"
 	out, err := helpers.WaitForCommandCompletion(ui, message,

--- a/cli/deployments/eirini.go
+++ b/cli/deployments/eirini.go
@@ -72,9 +72,10 @@ func (k Eirini) Delete(c *kubernetes.Cluster, ui *ui.UI) error {
 	defer os.RemoveAll(releaseDir)
 
 	for _, component := range []string{
+		"core/lrp-crd.yml",
+		"core/task-crd.yml",
 		"core/controller-deployment.yml",
 		"core/controller-rbac.yml",
-		"core/lrp-crd.yml",
 		"core/api-configmap.yml",
 		"workloads/app-rbac.yml",
 		"workloads/core/controller-rbac.yml",
@@ -205,9 +206,10 @@ func (k Eirini) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Insta
 	}
 
 	for _, component := range []string{
+		"core/lrp-crd.yml",
+		"core/task-crd.yml",
 		"core/controller-deployment.yml",
 		"core/controller-rbac.yml",
-		"core/lrp-crd.yml",
 		"core/api-configmap.yml",
 		"workloads/app-rbac.yml",
 		"workloads/core/controller-rbac.yml",

--- a/cli/deployments/eirini.go
+++ b/cli/deployments/eirini.go
@@ -71,7 +71,14 @@ func (k Eirini) Delete(c *kubernetes.Cluster, ui *ui.UI) error {
 	}
 	defer os.RemoveAll(releaseDir)
 
-	for _, component := range []string{"core", "events", "metrics", "workloads", "workloads/core"} {
+	for _, component := range []string{
+		"core/controller-deployment.yml",
+		"core/controller-rbac.yml",
+		"core/lrp-crd.yml",
+		"core/api-configmap.yml",
+		"workloads/app-rbac.yml",
+		"workloads/core/controller-rbac.yml",
+	} {
 		message := "Removing Eirini " + component
 		out, err := helpers.WaitForCommandCompletion(ui, message,
 			func() (string, error) {
@@ -197,7 +204,14 @@ func (k Eirini) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Insta
 		return errors.Wrapf(err, "%s failed:\n%s", message, out)
 	}
 
-	for _, component := range []string{"core", "events", "metrics", "workloads", "workloads/core"} {
+	for _, component := range []string{
+		"core/controller-deployment.yml",
+		"core/controller-rbac.yml",
+		"core/lrp-crd.yml",
+		"core/api-configmap.yml",
+		"workloads/app-rbac.yml",
+		"workloads/core/controller-rbac.yml",
+	} {
 		message := "Deploying Eirini " + component
 		out, err := helpers.WaitForCommandCompletion(ui, message,
 			func() (string, error) {
@@ -242,16 +256,11 @@ func (k Eirini) apply(c *kubernetes.Cluster, ui *ui.UI, options kubernetes.Insta
 		return err
 	}
 
-	for _, podname := range []string{
-		"eirini-api",
-		"eirini-metrics",
-	} {
-		if err := c.WaitUntilPodBySelectorExist(ui, "eirini-core", "name="+podname, k.Timeout); err != nil {
-			return errors.Wrap(err, "failed waiting Eirini "+podname+" deployment to exist")
-		}
-		if err := c.WaitForPodBySelectorRunning(ui, "eirini-core", "name="+podname, k.Timeout); err != nil {
-			return errors.Wrap(err, "failed waiting Eirini "+podname+" deployment to come up")
-		}
+	if err := c.WaitUntilPodBySelectorExist(ui, "eirini-core", "name=eirini-controller", k.Timeout); err != nil {
+		return errors.Wrap(err, "failed waiting Eirini eirini-controller deployment to exist")
+	}
+	if err := c.WaitForPodBySelectorRunning(ui, "eirini-core", "name=eirini-controller", k.Timeout); err != nil {
+		return errors.Wrap(err, "failed waiting Eirini eirini-controller deployment to come up")
 	}
 
 	ui.Success().Msg("Eirini deployed")


### PR DESCRIPTION
[Fixes #100]

We only need the quarks-secret from Quarks and only the eirini-controller from Eirini. The screenshot shows the pods created after this PR. Pushing the sample app still works.

![image](https://user-images.githubusercontent.com/2794419/106622905-c0cde080-657c-11eb-8424-8c9f0c8e9274.png)
