### PR TITLE
Add annotations to ingresses which are needed for Traefik v2

### DIFF
--- a/cli/embedded-files/eirini/routing.yaml
+++ b/cli/embedded-files/eirini/routing.yaml
@@ -86,3 +86,6 @@ spec:
               value: "eirini-workloads"
             - name: LABELS
               value: '{ "eirinix-ingress": "true", "kubernetes.io/ingress.class": "traefik" }'
+            - name: ANNOTATIONS
+              value: '{ "traefik.ingress.kubernetes.io/router.entrypoints": "websecure",
+                "traefik.ingress.kubernetes.io/router.tls": "true" }'


### PR DESCRIPTION
Documented here: https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/
Supported in eirini ingress since: https://github.com/mudler/eirini-ingress/commit/b4b364b7a0be3ac6c8be8fb1664c235abd57b69f

[Fixes #98]