### PR TITLE
Allow Acceptance tests to run in multiple ginkgo nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,7 @@ test: lint
 test-acceptance:
 	# Consider less nodes to avoid creating too many clusters which are not really needed
 	#ginkgo -p -stream acceptance/.
-	#ginkgo -nodes 2 -stream acceptance/.
-	ginkgo acceptance/.
-
+	ginkgo -nodes 2 -stream acceptance/.
 
 generate:
 	go generate ./...

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ carrier install
 ```bash
 $ carrier uninstall
 ```
----
+
 ### Push an application
 
 Run the following command for any supported application directory (e.g. inside [sample-app directory](sample-app)).
@@ -49,7 +49,7 @@ Always ensure that the chosen directory contains a supported application.
 ```bash
 $ carrier delete NAME
 ```
----
+
 ### Create a separate org
 
 ```bash
@@ -61,7 +61,7 @@ $ carrier create-org NAME
 ```bash
 $ carrier target NAME
 ```
----
+
 ### List all commands
 
 ```bash
@@ -72,3 +72,13 @@ $ carrier help
 ```bash
 $ carrier COMMAND --help
 ```
+
+## Configuration
+
+Carrier places its configuration at `$HOME/.config/carrier/config.yaml` by default.
+
+For exceptional situations this can be overriden by either specifying
+
+  - The global command-line option `--config-file`, or
+
+  - The environment variable `CARRIER_CONFIG`.

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -51,6 +51,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Printf("Creating a cluster for node %d\n", config.GinkgoConfig.ParallelNode)
 	createCluster()
 	os.Setenv("KUBECONFIG", nodeTmpDir+"/kubeconfig")
+	os.Setenv("CARRIER_CONFIG", nodeTmpDir+"/carrier.yaml")
 
 	fmt.Printf("Creating image pull secret for Dockerhub on node %d\n", config.GinkgoConfig.ParallelNode)
 	helpers.Kubectl(fmt.Sprintf("create secret docker-registry regcred --docker-server=%s --docker-username=%s --docker-password=%s",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/suse/carrier/cli/cmd/internal/client"
 	"github.com/suse/carrier/cli/kubernetes/config"
+	pconfig "github.com/suse/carrier/cli/paas/config"
 )
 
 const (
@@ -38,7 +39,11 @@ func Execute() {
 	pf := rootCmd.PersistentFlags()
 	argToEnv := map[string]string{}
 
-	pf.StringVarP(&flagConfigFile, "config-file", "", "", "set path of configuration file")
+	pf.StringVarP(&flagConfigFile, "config-file", "", pconfig.DefaultLocation(),
+		"set path of configuration file")
+	viper.BindPFlag("config-file", pf.Lookup("config-file"))
+	argToEnv["config-file"] = "CARRIER_CONFIG"
+
 	config.KubeConfigFlags(pf, argToEnv)
 	config.LoggerFlags(pf, argToEnv)
 

--- a/paas/config/config.go
+++ b/paas/config/config.go
@@ -23,16 +23,15 @@ type Config struct {
 	v *viper.Viper
 }
 
+// DefaultLocation returns the standard location for the configuration file
+func DefaultLocation() string {
+	return defaultConfigFilePath
+}
+
 // Load loads the Carrier config
 func Load(flags *pflag.FlagSet) (*Config, error) {
 	v := viper.New()
-
-	file := defaultConfigFilePath
-	if f, err := flags.GetString("config-file"); err == nil && f != "" {
-		file = f
-	} else if err != nil {
-		return nil, errors.Wrap(err, "failed to get config flag")
-	}
+	file := location()
 
 	v.SetConfigType("yaml")
 	v.SetConfigFile(file)
@@ -82,6 +81,10 @@ func (c *Config) Save() error {
 	}
 
 	return nil
+}
+
+func location() string {
+	return viper.GetString("config-file")
 }
 
 func fileExists(path string) (bool, error) {


### PR DESCRIPTION
Fixes #142.

  - Added support for environment variable `CARRIER_CONFIG` for config location.
  - Global cli option for config location already existed (`--config-file`).
  - Updated README, documenting the above
  - Use `CARRIER_CONFIG` in the :cat2: setup to place the config into ginkgo-node specific directories.
  - Re-enabled multi-node execution of :cat2: 
