### PR TITLE
fix: Wait for app pod to be removed before returning to caller

### DIFF
--- a/paas/client.go
+++ b/paas/client.go
@@ -206,10 +206,10 @@ func (c *CarrierClient) Delete(app string) error {
 	details.Info("delete repo")
 	_, err := c.giteaClient.DeleteRepo(c.config.Org, app)
 	if err != nil {
-		return errors.Wrap(err, "failed to delete repo")
+		return errors.Wrap(err, "failed to delete repository")
 	}
 
-	c.ui.Normal().Msg("Deleted app code repository.")
+	c.ui.Normal().Msg("Deleted application code repository.")
 
 	details.Info("delete deployment")
 
@@ -219,7 +219,20 @@ func (c *CarrierClient) Delete(app string) error {
 		return errors.Wrap(err, "failed to delete application deployment")
 	}
 
-	c.ui.Normal().Msg("Deleted app containers.")
+	// The command above removes the application's deployment.
+	// This in turn deletes the associated replicaset, and pod, in
+	// this order. The pod being gone thus indicates command
+	// completion, and is therefore what we are waiting on below.
+
+	err = c.kubeClient.WaitForPodBySelectorMissing(c.ui,
+		c.config.CarrierWorkloadsNamespace,
+		fmt.Sprintf("cloudfoundry.org/guid=%s.%s", c.config.Org, app),
+		DefaultTimeoutSec)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete application pod")
+	}
+
+	c.ui.Normal().Msg("Deleted application containers.")
 	c.ui.Success().Msg("Application deleted.")
 
 	return nil


### PR DESCRIPTION
Fixes #131 

Added support functions to detect pod non-existence, and to wait for
such. Used that new support to wait for a deleted application's pod to
be gone before continuing / returning to the user.