### PR TITLE
fix: Check for existing webhook before creating it

### DIFF
--- a/.github/workflows/lint_commit_messages.yml
+++ b/.github/workflows/lint_commit_messages.yml
@@ -12,7 +12,8 @@ jobs:
       - name: Setup gitlint
         run: sudo apt-get install gitlint
       - name: Checkout
-        run: git clone https://github.com/SUSE/carrier.git && cd carrier && git checkout ${GITHUB_HEAD_REF}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Lint new commits
-        working-directory: ./carrier
-        run: gitlint --commits "origin..HEAD"
+        run: gitlint --commits "origin/main..HEAD"

--- a/paas/client.go
+++ b/paas/client.go
@@ -474,7 +474,20 @@ func (c *CarrierClient) createRepo(name string) error {
 }
 
 func (c *CarrierClient) createRepoWebhook(name string) error {
-	c.ui.Normal().Msg("Creating webhook in the repo ...")
+	hooks, _, err := c.giteaClient.ListRepoHooks(c.config.Org, name, gitea.ListHooksOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to list webhooks")
+	}
+
+	for _, hook := range hooks {
+		url := hook.Config["url"]
+		if url == StagingEventListenerURL {
+			c.ui.Normal().Msg("Webhook already exists.")
+			return nil
+		}
+	}
+
+	c.ui.Normal().Msg("Creating webhook in the repo...")
 
 	c.giteaClient.CreateRepoHook(c.config.Org, name, gitea.CreateHookOption{
 		Active:       true,


### PR DESCRIPTION
When pushing an app, check if the webhook already exists before creating
it or it will crate a webhook for every push and consequently will trigger
the pipeline multiple times.