### PR TITLE
fix: Handle error when Deployment update fails

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -75,6 +75,9 @@ func (a *Application) Unbind(service interfaces.Service) error {
 		deployment,
 		metav1.UpdateOptions{},
 	)
+	if err != nil {
+		return err
+	}
 
 	// delete binding - DeleteBinding(a.Name)
 	return service.DeleteBinding(a.Name)


### PR DESCRIPTION
Not sure but this could explain how this failure could happen in
acceptance tests (the update failed but we ignored it?):

[2] • Failure [247.760 seconds]
[2] Catalog Services
[2] /home/runner/work/carrier/carrier/acceptance/catalog_services_test.go:15
[2]   unbind-service
[2]   /home/runner/work/carrier/carrier/acceptance/catalog_services_test.go:108
[2]     unbinds a service from the application deployment [It]
[2]     /home/runner/work/carrier/carrier/acceptance/catalog_services_test.go:134
[2]
[2]     Expected
[2]         <string>: [{"name":"service-610557624","secret":{"defaultMode":420,"secretName":"service.org-apps-org.svc-service-610557624.app-apps-146297823"}}]
[2]     not to match regular expression
[2]         <string>: service-610557624