### PR TITLE
fix: Do not delete Services with bound apps

### DIFF
--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -1,12 +1,6 @@
 package acceptance_test
 
 import (
-	"fmt"
-	"os"
-	"path"
-	"strconv"
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -14,33 +8,39 @@ import (
 var _ = Describe("Apps", func() {
 	var org = "apps-org"
 	BeforeEach(func() {
-		out, err := Carrier("create-org "+org, "")
-		Expect(err).ToNot(HaveOccurred(), out)
-		out, err = Carrier("target "+org, "")
-		Expect(err).ToNot(HaveOccurred(), out)
+		setupAndTargetOrg(org)
 	})
 	Describe("push and delete", func() {
 		var appName string
 		BeforeEach(func() {
-			appName = "apps-" + strconv.Itoa(int(time.Now().Nanosecond()))
+			appName = newAppName()
 		})
 
 		It("pushes and deletes an app", func() {
 			By("pushing the app")
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			appDir := path.Join(currentDir, "../sample-app")
-
-			out, err := Carrier(fmt.Sprintf("push %s --verbosity 1", appName), appDir)
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = Carrier("apps", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*`))
+			makeApp(appName)
 
 			By("deleting the app")
-			out, err = Carrier("delete "+appName, "")
+			deleteApp(appName)
+		})
+
+		It("unbinds bound services when deleting an app", func() {
+			serviceName := newServiceName()
+
+			makeApp(appName)
+			makeCustomService(serviceName)
+			bindAppService(appName, serviceName, org)
+
+			By("deleting the app")
+			out, err := Carrier("delete "+appName, "")
 			Expect(err).ToNot(HaveOccurred(), out)
 			// TODO: Fix `carrier delete` from returning before the app is deleted #131
+
+			Expect(out).To(MatchRegexp("Bound Services Found, Unbind Them"))
+			Expect(out).To(MatchRegexp("Unbinding"))
+			Expect(out).To(MatchRegexp("Service: " + serviceName))
+			Expect(out).To(MatchRegexp("Unbound"))
+
 			Eventually(func() string {
 				out, err := Carrier("apps", "")
 				Expect(err).ToNot(HaveOccurred(), out)

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -33,8 +33,8 @@ var _ = Describe("Bounds between Apps & Services", func() {
 		})
 		AfterEach(func() {
 			// Delete app first, as this also unbinds the service
-			deleteApp(appName)
-			deleteService(serviceName)
+			cleanupApp(appName)
+			cleanupService(serviceName)
 		})
 	})
 })

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -26,10 +26,11 @@ var _ = Describe("Bounds between Apps & Services", func() {
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp(serviceName + `.*` + appName))
 
-			out, err = Carrier("apps", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*` + serviceName))
-
+			Eventually(func() string {
+				out, err = Carrier("apps", "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}, "1m").Should(MatchRegexp(appName + `.*\|.*1\/1.*\|.*` + serviceName))
 		})
 		AfterEach(func() {
 			// Delete app first, as this also unbinds the service

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -1,0 +1,40 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Bounds between Apps & Services", func() {
+	var org = "apps-org"
+	BeforeEach(func() {
+		setupAndTargetOrg(org)
+	})
+	Describe("Display", func() {
+		var appName string
+		var serviceName string
+		BeforeEach(func() {
+			appName = newAppName()
+			serviceName = newServiceName()
+
+			makeApp(appName)
+			makeCustomService(serviceName)
+			bindAppService(appName, serviceName, org)
+		})
+		It("shows the bound app for services, and vice versa", func() {
+			out, err := Carrier("services", "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp(serviceName + `.*` + appName))
+
+			out, err = Carrier("apps", "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*` + serviceName))
+
+		})
+		AfterEach(func() {
+			// Delete app first, as this also unbinds the service
+			deleteApp(appName)
+			deleteService(serviceName)
+		})
+	})
+})

--- a/acceptance/catalog_services_test.go
+++ b/acceptance/catalog_services_test.go
@@ -1,159 +1,112 @@
 package acceptance_test
 
 import (
-	"fmt"
-	"os"
-	"path"
-	"strconv"
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/suse/carrier/helpers"
 )
 
 var _ = Describe("Catalog Services", func() {
 	var org = "apps-org"
 	var serviceName string
 	BeforeEach(func() {
-		serviceName = "service-" + strconv.Itoa(int(time.Now().Nanosecond()))
-
-		out, err := Carrier("create-org "+org, "")
-		Expect(err).ToNot(HaveOccurred(), out)
-		out, err = Carrier("target "+org, "")
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		out, err = Carrier("enable services-incluster", "")
-		Expect(err).ToNot(HaveOccurred(), out)
-
-		// Wait until plans appear
-		Eventually(func() error {
-			_, err = helpers.Kubectl("get clusterserviceclass mariadb")
-			return err
-		}, "5m").ShouldNot(HaveOccurred())
+		serviceName = newServiceName()
+		setupAndTargetOrg(org)
+		setupInClusterServices()
 	})
 
 	Describe("create-service", func() {
-		AfterEach(func() {
-			out, err := Carrier(fmt.Sprintf("delete-service %s", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-		})
-
 		It("creates a catalog based service", func() {
-			out, err := Carrier(fmt.Sprintf("create-service %s mariadb 10-3-22", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = Carrier("services", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp(serviceName))
+			makeCatalogService(serviceName)
+		})
+		AfterEach(func() {
+			deleteService(serviceName)
 		})
 	})
 
 	Describe("delete service", func() {
 		BeforeEach(func() {
-			out, err := Carrier(fmt.Sprintf("create-service %s mariadb 10-3-22", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			makeCatalogService(serviceName)
 		})
 
 		It("deletes a catalog based service", func() {
+			deleteService(serviceName)
+		})
+
+		It("doesn't delete a bound service", func() {
+			appName := newAppName()
+			makeApp(appName)
+			bindAppService(appName, serviceName, org)
+
 			out, err := Carrier("delete-service "+serviceName, "")
 			Expect(err).ToNot(HaveOccurred(), out)
 
+			Expect(out).To(MatchRegexp("Unable to delete service. It is still used by"))
+			Expect(out).To(MatchRegexp(appName))
+			Expect(out).To(MatchRegexp("Use --unbind to force the issue"))
+
+			verifyAppServiceBound(appName, serviceName, org)
+
+			// Delete again, and force unbind
+
+			out, err = Carrier("delete-service --unbind "+serviceName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Expect(out).To(MatchRegexp("Unbinding Service From Using Applications Before Deletion"))
+			Expect(out).To(MatchRegexp(appName))
+
+			Expect(out).To(MatchRegexp("Unbinding"))
+			Expect(out).To(MatchRegexp("Application: " + appName))
+			Expect(out).To(MatchRegexp("Unbound"))
+
+			Expect(out).To(MatchRegexp("Service Removed"))
+
+			verifyAppServiceNotbound(appName, serviceName, org)
+
+			// And check non-presence
 			Eventually(func() string {
 				out, err = Carrier("services", "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "10m").ShouldNot(MatchRegexp(serviceName))
 		})
-
-		PIt("doesn't delete a bound service", func() {
-		})
 	})
 
 	Describe("bind-service", func() {
 		var appName string
 		BeforeEach(func() {
-			appName = "apps-" + strconv.Itoa(int(time.Now().Nanosecond()))
+			appName = newAppName()
 
-			out, err := Carrier(fmt.Sprintf("create-service %s mariadb 10-3-22", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			appDir := path.Join(currentDir, "../sample-app")
-			out, err = Carrier(fmt.Sprintf("push %s --verbosity 1", appName), appDir)
-			Expect(err).ToNot(HaveOccurred(), out)
+			makeCatalogService(serviceName)
+			makeApp(appName)
 		})
 
 		AfterEach(func() {
-			out, err := Carrier(fmt.Sprintf("unbind-service %s %s", serviceName, appName), "")
-			if err != nil {
-				fmt.Printf("unbinding service failed: %s\n%s", err.Error(), out)
-			}
-
-			out, err = Carrier("delete "+appName, "")
-			if err != nil {
-				fmt.Printf("deleting app failed : %s\n%s", err.Error(), out)
-			}
-
-			out, err = Carrier("delete-service "+serviceName, "")
-			if err != nil {
-				fmt.Printf("deleting service failed : %s\n%s", err.Error(), out)
-			}
+			deleteApp(appName)
+			deleteService(serviceName)
 		})
 
 		It("binds a service to the application deployment", func() {
-			out, err := Carrier(fmt.Sprintf("bind-service %s %s", serviceName, appName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.volumes}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp(serviceName))
-
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.containers[0].volumeMounts}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp("/services/" + serviceName))
+			bindAppService(appName, serviceName, org)
 		})
 	})
 
 	Describe("unbind-service", func() {
 		var appName string
 		BeforeEach(func() {
-			appName = "apps-" + strconv.Itoa(int(time.Now().Nanosecond()))
+			appName = newAppName()
 
-			out, err := Carrier(fmt.Sprintf("create-service %s mariadb 10-3-22", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			appDir := path.Join(currentDir, "../sample-app")
-			out, err = Carrier(fmt.Sprintf("push %s --verbosity 1", appName), appDir)
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			out, err = Carrier(fmt.Sprintf("bind-service %s %s", serviceName, appName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			makeCatalogService(serviceName)
+			makeApp(appName)
+			bindAppService(appName, serviceName, org)
 		})
 
 		AfterEach(func() {
-			out, err := Carrier("delete "+appName, "")
-			if err != nil {
-				fmt.Printf("deleting apps failed : %s\n%s", err.Error(), out)
-			}
-
-			out, err = Carrier("delete-service "+serviceName, "")
-			if err != nil {
-				fmt.Printf("deleting service failed : %s\n%s", err.Error(), out)
-			}
+			deleteApp(appName)
+			deleteService(serviceName)
 		})
 
 		It("unbinds a service from the application deployment", func() {
-			out, err := Carrier(fmt.Sprintf("unbind-service %s %s", serviceName, appName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.volumes}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).ToNot(MatchRegexp(serviceName))
-
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.containers[0].volumeMounts}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).ToNot(MatchRegexp("/services/" + serviceName))
+			unbindAppService(appName, serviceName, org)
 		})
 	})
 })

--- a/acceptance/catalog_services_test.go
+++ b/acceptance/catalog_services_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Catalog Services", func() {
 			makeCatalogService(serviceName)
 		})
 		AfterEach(func() {
-			deleteService(serviceName)
+			cleanupService(serviceName)
 		})
 	})
 
@@ -81,8 +81,8 @@ var _ = Describe("Catalog Services", func() {
 		})
 
 		AfterEach(func() {
-			deleteApp(appName)
-			deleteService(serviceName)
+			cleanupApp(appName)
+			cleanupService(serviceName)
 		})
 
 		It("binds a service to the application deployment", func() {
@@ -101,8 +101,8 @@ var _ = Describe("Catalog Services", func() {
 		})
 
 		AfterEach(func() {
-			deleteApp(appName)
-			deleteService(serviceName)
+			cleanupApp(appName)
+			cleanupService(serviceName)
 		})
 
 		It("unbinds a service from the application deployment", func() {

--- a/acceptance/custom_services_test.go
+++ b/acceptance/custom_services_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Custom Services", func() {
 			makeCustomService(serviceName)
 		})
 		AfterEach(func() {
-			deleteService(serviceName)
+			cleanupService(serviceName)
 		})
 	})
 
@@ -79,8 +79,8 @@ var _ = Describe("Custom Services", func() {
 		})
 
 		AfterEach(func() {
-			deleteApp(appName)
-			deleteService(serviceName)
+			cleanupApp(appName)
+			cleanupService(serviceName)
 		})
 
 		It("binds a service to the application deployment", func() {
@@ -99,8 +99,8 @@ var _ = Describe("Custom Services", func() {
 		})
 
 		AfterEach(func() {
-			deleteApp(appName)
-			deleteService(serviceName)
+			cleanupApp(appName)
+			cleanupService(serviceName)
 		})
 
 		It("unbinds a service from the application deployment", func() {

--- a/acceptance/custom_services_test.go
+++ b/acceptance/custom_services_test.go
@@ -1,128 +1,110 @@
 package acceptance_test
 
 import (
-	"fmt"
-	"os"
-	"path"
-	"strconv"
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/suse/carrier/helpers"
 )
 
 var _ = Describe("Custom Services", func() {
 	var org = "apps-org"
 	var serviceName string
 	BeforeEach(func() {
-		serviceName = "service-" + strconv.Itoa(int(time.Now().Nanosecond()))
-
-		out, err := Carrier("create-org "+org, "")
-		Expect(err).ToNot(HaveOccurred(), out)
-		out, err = Carrier("target "+org, "")
-		Expect(err).ToNot(HaveOccurred(), out)
+		serviceName = newServiceName()
+		setupAndTargetOrg(org)
 	})
 	Describe("create-custom-service", func() {
 		It("creates a custom service", func() {
-			out, err := Carrier(fmt.Sprintf("create-custom-service %s username carrier-user", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = Carrier("services", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp(serviceName))
+			makeCustomService(serviceName)
+		})
+		AfterEach(func() {
+			deleteService(serviceName)
 		})
 	})
 
 	Describe("delete service", func() {
 		BeforeEach(func() {
-			out, err := Carrier(fmt.Sprintf("create-custom-service %s username carrier-user", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			makeCustomService(serviceName)
 		})
 
 		It("deletes a custom service", func() {
-			out, err := Carrier("delete-service "+serviceName, "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = Carrier("services", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).ToNot(MatchRegexp(serviceName))
+			deleteService(serviceName)
 		})
 
-		PIt("doesn't delete a bound service", func() {
+		It("doesn't delete a bound service", func() {
+			appName := newAppName()
+			makeApp(appName)
+			bindAppService(appName, serviceName, org)
+
+			out, err := Carrier("delete-service "+serviceName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Expect(out).To(MatchRegexp("Unable to delete service. It is still used by"))
+			Expect(out).To(MatchRegexp(appName))
+			Expect(out).To(MatchRegexp("Use --unbind to force the issue"))
+
+			verifyAppServiceBound(appName, serviceName, org)
+
+			// Delete again, and force unbind
+
+			out, err = Carrier("delete-service --unbind "+serviceName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Expect(out).To(MatchRegexp("Unbinding Service From Using Applications Before Deletion"))
+			Expect(out).To(MatchRegexp(appName))
+
+			Expect(out).To(MatchRegexp("Unbinding"))
+			Expect(out).To(MatchRegexp("Application: " + appName))
+			Expect(out).To(MatchRegexp("Unbound"))
+
+			Expect(out).To(MatchRegexp("Service Removed"))
+
+			verifyAppServiceNotbound(appName, serviceName, org)
+
+			// And check non-presence
+			Eventually(func() string {
+				out, err = Carrier("services", "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}, "2m").ShouldNot(MatchRegexp(serviceName))
 		})
 	})
 
 	Describe("bind-service", func() {
 		var appName string
 		BeforeEach(func() {
-			appName = "apps-" + strconv.Itoa(int(time.Now().Nanosecond()))
+			appName = newAppName()
 
-			out, err := Carrier(fmt.Sprintf("create-custom-service %s username carrier-user", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			appDir := path.Join(currentDir, "../sample-app")
-			out, err = Carrier(fmt.Sprintf("push %s --verbosity 1", appName), appDir)
-			Expect(err).ToNot(HaveOccurred(), out)
+			makeCustomService(serviceName)
+			makeApp(appName)
 		})
 
 		AfterEach(func() {
-			out, err := Carrier("delete "+appName, "")
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			out, err = Carrier("delete-service "+serviceName, "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			deleteApp(appName)
+			deleteService(serviceName)
 		})
 
 		It("binds a service to the application deployment", func() {
-			out, err := Carrier(fmt.Sprintf("bind-service %s %s", serviceName, appName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.volumes}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp(serviceName))
-
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.containers[0].volumeMounts}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp("/services/" + serviceName))
+			bindAppService(appName, serviceName, org)
 		})
 	})
 
 	Describe("unbind-service", func() {
 		var appName string
 		BeforeEach(func() {
-			appName = "apps-" + strconv.Itoa(int(time.Now().Nanosecond()))
+			appName = newAppName()
 
-			out, err := Carrier(fmt.Sprintf("create-custom-service %s username carrier-user", serviceName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			currentDir, err := os.Getwd()
-			Expect(err).ToNot(HaveOccurred())
-			appDir := path.Join(currentDir, "../sample-app")
-			out, err = Carrier(fmt.Sprintf("push %s --verbosity 1", appName), appDir)
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			out, err = Carrier(fmt.Sprintf("bind-service %s %s", serviceName, appName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			makeCustomService(serviceName)
+			makeApp(appName)
+			bindAppService(appName, serviceName, org)
 		})
 
 		AfterEach(func() {
-			out, err := Carrier("delete "+appName, "")
-			Expect(err).ToNot(HaveOccurred(), out)
-
-			out, err = Carrier("delete-service "+serviceName, "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			deleteApp(appName)
+			deleteService(serviceName)
 		})
 
 		It("unbinds a service from the application deployment", func() {
-			out, err := Carrier(fmt.Sprintf("unbind-service %s %s", serviceName, appName), "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.volumes}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).ToNot(MatchRegexp(serviceName))
-
-			out, err = helpers.Kubectl(fmt.Sprintf("get deployment -n carrier-workloads %s.%s -o=jsonpath='{.spec.template.spec.containers[0].volumeMounts}'", org, appName))
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).ToNot(MatchRegexp("/services/" + serviceName))
+			unbindAppService(appName, serviceName, org)
 		})
 	})
 })

--- a/acceptance/features_test.go
+++ b/acceptance/features_test.go
@@ -18,10 +18,9 @@ var _ = Describe("Carrier enable/disable features", func() {
 		})
 
 		It("enables minibroker services", func() {
-			out, err := Carrier("enable services-incluster", "")
-			Expect(err).ToNot(HaveOccurred(), out)
+			setupInClusterServices()
 
-			out, err = helpers.Kubectl(`get pods -n minibroker --selector=app=minibroker-minibroker`)
+			out, err := helpers.Kubectl(`get pods -n minibroker --selector=app=minibroker-minibroker`)
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp(`minibroker.*1/1.*Running`))
 		})

--- a/acceptance/orgs_test.go
+++ b/acceptance/orgs_test.go
@@ -14,22 +14,10 @@ var _ = Describe("Orgs", func() {
 
 	Describe("create-org", func() {
 		It("creates and targets an org", func() {
-			By("creating an org")
-			out, err := Carrier("create-org mycreatedorg", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			orgs, err := Carrier("orgs", "")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(orgs).To(MatchRegexp("mycreatedorg"))
-
-			By("targeting an org")
-			out, err = Carrier("target mycreatedorg", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			out, err = Carrier("target", "")
-			Expect(err).ToNot(HaveOccurred(), out)
-			Expect(out).To(MatchRegexp("Currently targeted organization: mycreatedorg"))
+			setupAndTargetOrg("mycreatedorg")
 
 			By("switching org back to default")
-			out, err = Carrier("target workspace", "")
+			out, err := Carrier("target workspace", "")
 			Expect(err).ToNot(HaveOccurred(), out)
 		})
 	})

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -132,7 +132,7 @@ func deleteService(serviceName string) {
 		out, err = Carrier("services", "")
 		Expect(err).ToNot(HaveOccurred(), out)
 		return out
-	}, "2m").ShouldNot(MatchRegexp(serviceName))
+	}, "10m").ShouldNot(MatchRegexp(serviceName))
 }
 
 func unbindAppService(appName, serviceName, org string) {

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -123,6 +123,15 @@ func deleteApp(appName string) {
 	}, "1m").ShouldNot(MatchRegexp(`.*%s.*`, appName))
 }
 
+func cleanupApp(appName string) {
+	out, err := Carrier("delete "+appName, "")
+	// TODO: Fix `carrier delete` from returning before the app is deleted #131
+
+	if err != nil {
+		fmt.Printf("deleting app failed : %s\n%s", err.Error(), out)
+	}
+}
+
 func deleteService(serviceName string) {
 	out, err := Carrier("delete-service "+serviceName, "")
 	Expect(err).ToNot(HaveOccurred(), out)
@@ -135,12 +144,27 @@ func deleteService(serviceName string) {
 	}, "10m").ShouldNot(MatchRegexp(serviceName))
 }
 
+func cleanupService(serviceName string) {
+	out, err := Carrier("delete-service "+serviceName, "")
+
+	if err != nil {
+		fmt.Printf("deleting service failed : %s\n%s", err.Error(), out)
+	}
+}
+
 func unbindAppService(appName, serviceName, org string) {
 	out, err := Carrier(fmt.Sprintf("unbind-service %s %s", serviceName, appName), "")
 	Expect(err).ToNot(HaveOccurred(), out)
 
 	// And deep check in kube structures for non-presence
 	verifyAppServiceNotbound(appName, serviceName, org)
+}
+
+func cleanUnbindAppService(appName, serviceName, org string) {
+	out, err := Carrier(fmt.Sprintf("unbind-service %s %s", serviceName, appName), "")
+	if err != nil {
+		fmt.Printf("unbinding service failed: %s\n%s", err.Error(), out)
+	}
 }
 
 func verifyAppServiceNotbound(appName, serviceName, org string) {

--- a/cmd/internal/client/delete-service.go
+++ b/cmd/internal/client/delete-service.go
@@ -8,6 +8,10 @@ import (
 
 var ()
 
+func init() {
+	CmdDeleteService.Flags().Bool("unbind", false, "Unbind from applications before deleting")
+}
+
 // CmdDeleteService implements the carrier delete-service command
 var CmdDeleteService = &cobra.Command{
 	Use:   "delete-service NAME",
@@ -15,6 +19,11 @@ var CmdDeleteService = &cobra.Command{
 	Long:  `Delete service by name.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		unbind, err := cmd.Flags().GetBool("unbind")
+		if err != nil {
+			return err
+		}
+
 		client, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
@@ -26,7 +35,7 @@ var CmdDeleteService = &cobra.Command{
 			return errors.Wrap(err, "error initializing cli")
 		}
 
-		err = client.DeleteService(args[0])
+		err = client.DeleteService(args[0], unbind)
 		if err != nil {
 			return errors.Wrap(err, "error deleting service")
 		}

--- a/cmd/internal/client/unbind-service.go
+++ b/cmd/internal/client/unbind-service.go
@@ -28,7 +28,7 @@ var CmdUnbindService = &cobra.Command{
 
 		err = client.UnbindService(args[0], args[1])
 		if err != nil {
-			return errors.Wrap(err, "error creating service")
+			return errors.Wrap(err, "error unbinding service")
 		}
 
 		return nil

--- a/paas/client.go
+++ b/paas/client.go
@@ -589,9 +589,6 @@ func (c *CarrierClient) CreateOrg(org string) error {
 
 // Delete removes the named application from the cluster
 func (c *CarrierClient) Delete(appname string) error {
-	// TODO: lookup app, (get object), invoke action.
-	// TODO: Move action here into `internal/application`.
-
 	log := c.Log.WithName("Delete").WithValues("Application", appname)
 	log.Info("start")
 	defer log.Info("return")

--- a/paas/client.go
+++ b/paas/client.go
@@ -407,8 +407,6 @@ func (c *CarrierClient) Info() error {
 // AppsMatching returns all Carrier apps having the specified prefix
 // in their name.
 func (c *CarrierClient) AppsMatching(prefix string) []string {
-	// TODO: change to use application.List()
-
 	log := c.Log.WithName("AppsMatching").WithValues("PrefixToMatch", prefix)
 	log.Info("start")
 	defer log.Info("return")
@@ -416,7 +414,7 @@ func (c *CarrierClient) AppsMatching(prefix string) []string {
 
 	result := []string{}
 
-	apps, _, err := c.giteaClient.ListOrgRepos(c.config.Org, gitea.ListOrgReposOptions{})
+	apps, err := application.List(c.kubeClient, c.giteaClient, c.config.Org)
 	if err != nil {
 		return result
 	}
@@ -435,8 +433,6 @@ func (c *CarrierClient) AppsMatching(prefix string) []string {
 
 // Apps gets all Carrier apps in the targeted org
 func (c *CarrierClient) Apps() error {
-	// TODO: change to use application.List()
-
 	log := c.Log.WithName("Apps").WithValues("Organization", c.config.Org)
 	log.Info("start")
 	defer log.Info("return")
@@ -453,7 +449,7 @@ func (c *CarrierClient) Apps() error {
 	}
 
 	details.Info("gitea list org repos")
-	apps, _, err := c.giteaClient.ListOrgRepos(c.config.Org, gitea.ListOrgReposOptions{})
+	apps, err := application.List(c.kubeClient, c.giteaClient, c.config.Org)
 	if err != nil {
 		return errors.Wrap(err, "failed to list apps")
 	}

--- a/paas/client.go
+++ b/paas/client.go
@@ -481,7 +481,7 @@ func (c *CarrierClient) Apps() error {
 	for _, app := range apps {
 		details.Info("kube get status", "App", app.Name)
 		status, err := c.kubeClient.DeploymentStatus(
-			c.config.CarrierWorkloadsNamespace,
+			deployments.WorkloadsDeploymentID,
 			fmt.Sprintf("carrier/app-guid=%s.%s", c.config.Org, app.Name),
 		)
 		if err != nil {
@@ -490,7 +490,7 @@ func (c *CarrierClient) Apps() error {
 
 		details.Info("kube get ingress", "App", app.Name)
 		routes, err := c.kubeClient.ListIngressRoutes(
-			c.config.CarrierWorkloadsNamespace,
+			deployments.WorkloadsDeploymentID,
 			app.Name)
 		if err != nil {
 			routes = []string{color.RedString(err.Error())}
@@ -1016,7 +1016,7 @@ func (c *CarrierClient) logs(name string) (context.CancelFunc, error) {
 		TailLines:             nil,
 		Template:              tailer.DefaultSingleNamespaceTemplate(),
 
-		Namespace: "carrier-workloads",
+		Namespace: deployments.WorkloadsDeploymentID,
 		PodQuery:  regexp.MustCompile(fmt.Sprintf(".*-%s-.*", name)),
 	}, c.kubeClient)
 	if err != nil {
@@ -1029,7 +1029,7 @@ func (c *CarrierClient) logs(name string) (context.CancelFunc, error) {
 func (c *CarrierClient) waitForApp(org, name string) error {
 	c.ui.ProgressNote().KeeplineUnder(1).Msg("Creating application resources")
 	err := c.kubeClient.WaitUntilPodBySelectorExist(
-		c.ui, c.config.CarrierWorkloadsNamespace,
+		c.ui, deployments.WorkloadsDeploymentID,
 		fmt.Sprintf("cloudfoundry.org/guid=%s.%s", org, name),
 		duration.ToAppBuilt())
 	if err != nil {
@@ -1039,7 +1039,7 @@ func (c *CarrierClient) waitForApp(org, name string) error {
 	c.ui.ProgressNote().KeeplineUnder(1).Msg("Starting application")
 
 	err = c.kubeClient.WaitForPodBySelectorRunning(
-		c.ui, c.config.CarrierWorkloadsNamespace,
+		c.ui, deployments.WorkloadsDeploymentID,
 		fmt.Sprintf("cloudfoundry.org/guid=%s.%s", org, name),
 		duration.ToPodReady())
 

--- a/paas/config/config.go
+++ b/paas/config/config.go
@@ -16,9 +16,8 @@ var (
 
 // Config represents a carrier config
 type Config struct {
-	GiteaProtocol             string `mapstructure:"gitea_protocol"`
-	CarrierWorkloadsNamespace string `mapstructure:"carrier_workloads_namespace"`
-	Org                       string `mapstructure:"org"`
+	GiteaProtocol string `mapstructure:"gitea_protocol"`
+	Org           string `mapstructure:"org"`
 
 	v *viper.Viper
 }

--- a/paas/gitea/resolver.go
+++ b/paas/gitea/resolver.go
@@ -88,7 +88,7 @@ func (r *Resolver) GetGiteaURL() (string, error) {
 
 // GetGiteaCredentials resolves Gitea's credentials
 func (r *Resolver) GetGiteaCredentials() (string, string, error) {
-	s, err := r.cluster.GetSecret(r.config.CarrierWorkloadsNamespace, GiteaCredentialsSecret)
+	s, err := r.cluster.GetSecret(deployments.WorkloadsDeploymentID, GiteaCredentialsSecret)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to read gitea credentials")
 	}


### PR DESCRIPTION
Fixes #198 .

- Do not delete services with bound apps. Shows the bound apps.
- Force delete services with bound apps, via `--unbind`. Service is unbound from apps before deletion. Shows the bound apps.
- Deleting an app unbinds all bound services first. Shows the bound services.
- Show bound apps per service when listing services.
- Show bound services per app, when listing apps.

Chores:
- Switched cli backends involving app listing to the application package
- Switched to `deployments.workloadsDeploymentID` for the app namespace. Removing the configuration element.

:heavy_check_mark: local :cat2: 
