### PR TITLE
fix: Type assertion could fail. Only continue if true

### DIFF
--- a/kubernetes/tailer/watcher.go
+++ b/kubernetes/tailer/watcher.go
@@ -47,7 +47,11 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 					return
 				}
 
-				pod := e.Object.(*corev1.Pod)
+				pod, ok := e.Object.(*corev1.Pod)
+				if !ok {
+					// Not a Pod
+					return
+				}
 
 				if !podFilter.MatchString(pod.Name) {
 					continue


### PR DESCRIPTION
I got this error while running acceptance tests:

```
[1]   panic: interface conversion: runtime.Object is *v1.Status, not *v1.Pod
[1]
[1]   goroutine 53 [running]:
[1]   github.com/suse/carrier/kubernetes/tailer.Watch.func1( ...
[1]     /home/opensuse/workspace/carrier/kubernetes/tailer/watcher.go:50 +0xfef
[1]   created by github.com/suse/carrier/kubernetes/tailer.Watch
[1]     /home/opensuse/workspace/carrier/kubernetes/tailer/watcher.go:41 +0x2ee
```

Which means we could get objects that are not Pods through the Watcher.
We only care about Pods so we just return in other cases.