### PR TITLE
Fix: Wait for service to be provisioned

### DIFF
--- a/acceptance/catalog_services_test.go
+++ b/acceptance/catalog_services_test.go
@@ -15,9 +15,14 @@ var _ = Describe("Catalog Services", func() {
 	})
 
 	Describe("create-service", func() {
-		It("creates a catalog based service", func() {
+		It("creates a catalog based service, with waiting", func() {
 			makeCatalogService(serviceName)
 		})
+
+		It("creates a catalog based service, without waiting", func() {
+			makeCatalogServiceDontWait(serviceName)
+		})
+
 		AfterEach(func() {
 			cleanupService(serviceName)
 		})
@@ -107,6 +112,25 @@ var _ = Describe("Catalog Services", func() {
 
 		It("unbinds a service from the application deployment", func() {
 			unbindAppService(appName, serviceName, org)
+		})
+	})
+
+	Describe("service", func() {
+		BeforeEach(func() {
+			makeCatalogService(serviceName)
+		})
+
+		It("it shows service details", func() {
+			out, err := Carrier("service "+serviceName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("Service Details"))
+			Expect(out).To(MatchRegexp(`Status .*\|.* Provisioned`))
+			Expect(out).To(MatchRegexp(`Class .*\|.* mariadb`))
+			Expect(out).To(MatchRegexp(`Plan .*\|.* 10-3-22`))
+		})
+
+		AfterEach(func() {
+			cleanupService(serviceName)
 		})
 	})
 })

--- a/acceptance/custom_services_test.go
+++ b/acceptance/custom_services_test.go
@@ -12,10 +12,15 @@ var _ = Describe("Custom Services", func() {
 		serviceName = newServiceName()
 		setupAndTargetOrg(org)
 	})
+
 	Describe("create-custom-service", func() {
+		// Note: Custom Services provision instantly.
+		// No testing of wait/don't wait required.
+
 		It("creates a custom service", func() {
 			makeCustomService(serviceName)
 		})
+
 		AfterEach(func() {
 			cleanupService(serviceName)
 		})
@@ -105,6 +110,24 @@ var _ = Describe("Custom Services", func() {
 
 		It("unbinds a service from the application deployment", func() {
 			unbindAppService(appName, serviceName, org)
+		})
+	})
+
+	Describe("service", func() {
+		BeforeEach(func() {
+			makeCustomService(serviceName)
+		})
+
+		It("it shows service details", func() {
+			out, err := Carrier("service "+serviceName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("Service Details"))
+			Expect(out).To(MatchRegexp(`Status .*\|.* Provisioned`))
+			Expect(out).To(MatchRegexp(`username .*\|.* carrier-user`))
+		})
+
+		AfterEach(func() {
+			cleanupService(serviceName)
 		})
 	})
 })

--- a/acceptance/services_test.go
+++ b/acceptance/services_test.go
@@ -1,0 +1,37 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Services", func() {
+	var org = "apps-org"
+	var serviceCatalogName string
+	var serviceCustomName string
+	BeforeEach(func() {
+		serviceCatalogName = newServiceName()
+		serviceCustomName = newServiceName()
+		setupAndTargetOrg(org)
+		setupInClusterServices()
+	})
+
+	Describe("services", func() {
+		BeforeEach(func() {
+			makeCatalogService(serviceCatalogName)
+			makeCustomService(serviceCustomName)
+		})
+
+		It("shows all created services", func() {
+			out, err := Carrier("services", "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp(serviceCustomName))
+			Expect(out).To(MatchRegexp(serviceCatalogName))
+		})
+
+		AfterEach(func() {
+			cleanupService(serviceCatalogName)
+			cleanupService(serviceCustomName)
+		})
+	})
+})

--- a/cmd/internal/client/create-service.go
+++ b/cmd/internal/client/create-service.go
@@ -8,6 +8,10 @@ import (
 
 var ()
 
+func init() {
+	CmdCreateService.Flags().Bool("dont-wait", false, "Return immediately, without waiting for the service to be provisioned")
+}
+
 // CmdCreateService implements the carrier create-service command
 var CmdCreateService = &cobra.Command{
 	Use:   "create-service NAME CLASS PLAN ?(KEY VALUE)...?",
@@ -34,7 +38,13 @@ var CmdCreateService = &cobra.Command{
 			return errors.Wrap(err, "error initializing cli")
 		}
 
-		err = client.CreateService(args[0], args[1], args[2], args[3:])
+		dw, err := cmd.Flags().GetBool("dont-wait")
+		if err != nil {
+			return err
+		}
+		waitforProvision := !dw
+
+		err = client.CreateService(args[0], args[1], args[2], args[3:], waitforProvision)
 		if err != nil {
 			return errors.Wrap(err, "error creating service")
 		}

--- a/cmd/internal/client/service.go
+++ b/cmd/internal/client/service.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/suse/carrier/paas"
+)
+
+var ()
+
+// CmdService implements the carrier -service command
+var CmdService = &cobra.Command{
+	Use:   "service NAME",
+	Short: "Service information",
+	Long:  `Show detailed information of the named service.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, cleanup, err := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.ServiceDetails(args[0])
+		if err != nil {
+			return errors.Wrap(err, "error retrieving service")
+		}
+
+		return nil
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		matches := app.ServiceMatching(toComplete)
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func Execute() {
 	rootCmd.AddCommand(client.CmdBindService)
 	rootCmd.AddCommand(client.CmdUnbindService)
 	rootCmd.AddCommand(client.CmdServices)
+	rootCmd.AddCommand(client.CmdService)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -10,11 +10,12 @@ import (
 )
 
 const (
-	systemDomain  = 2 * time.Minute
-	deployment    = 5 * time.Minute
-	serviceSecret = 5 * time.Minute
-	podReady      = 5 * time.Minute
-	appBuilt      = 33 * time.Minute
+	systemDomain     = 2 * time.Minute
+	deployment       = 5 * time.Minute
+	serviceSecret    = 5 * time.Minute
+	serviceProvision = 5 * time.Minute
+	podReady         = 5 * time.Minute
+	appBuilt         = 33 * time.Minute
 
 	// Fixed. __Not__ affected by the multiplier.
 	pollInterval = 3 * time.Second
@@ -62,6 +63,12 @@ func ToDeployment() time.Duration {
 // catalog service binding to appear
 func ToServiceSecret() time.Duration {
 	return Multiplier() * serviceSecret
+}
+
+// ToServiceProvision returns the duration to wait for a catalog
+// service instance to be provisioned
+func ToServiceProvision() time.Duration {
+	return Multiplier() * serviceProvision
 }
 
 //

--- a/internal/interfaces/interfaces.go
+++ b/internal/interfaces/interfaces.go
@@ -12,6 +12,9 @@ type Service interface {
 	GetBinding(appName string) (*corev1.Secret, error)
 	DeleteBinding(appName string) error
 	Delete() error
+	Status() (string, error)
+	Details() (map[string]string, error)
+	WaitForProvision() error
 }
 
 type ServiceList []Service

--- a/internal/services/custom_service.go
+++ b/internal/services/custom_service.go
@@ -151,3 +151,30 @@ func (s *CustomService) DeleteBinding(appName string) error {
 func (s *CustomService) Delete() error {
 	return s.kubeClient.DeleteSecret(deployments.WorkloadsDeploymentID, s.SecretName)
 }
+
+func (s *CustomService) Status() (string, error) {
+	return "Provisioned", nil
+}
+
+func (s *CustomService) WaitForProvision() error {
+	// Custom services provision instantly. No waiting
+	return nil
+}
+
+func (s *CustomService) Details() (map[string]string, error) {
+	serviceSecret, err := s.kubeClient.GetSecret(deployments.WorkloadsDeploymentID, s.SecretName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.New("service does not exist")
+		}
+		return nil, err
+	}
+
+	details := map[string]string{}
+
+	for k, v := range serviceSecret.Data {
+		details[k] = string(v)
+	}
+
+	return details, nil
+}


### PR DESCRIPTION
Fixes #199 

- New command `service` to show service details, and status
- Extended `create-service` to wait for the new service to be provisioned by default
- Added option `--dont-wait` to tell `create-service` that it shall not wait as above.
- Added acceptance tests around `--dont-wait`, and for the new `service` command.

:heavy_check_mark: of local :cat2: (extended test suite)
