### PR TITLE
test: Disable workflows on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == "SUSE/carrier"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
because we want to use self hosted GitHub Actions workers. There is no
way to use shared (GHA provided) workers just for forks and stick to
self hosted for our repository. This is a security problem because
anyone can just open a PR and start running artbitrary code on our
workers.

With this in place, in order to tests PRs from forks, a contributor on
our repository should create a copy of the forked PR (after reviewing
the code) in order to trigger tests. That copy should be updated with
every update of the original PR until it's merged.

https://github.community/t/stop-github-actions-running-on-a-fork/17965/2