### PR TITLE
feat: Warm up Carrier cluster and reduce app push timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: lint
 
 GINKGO_NODES ?= 2
 test-acceptance:
-	ginkgo -nodes ${GINKGO_NODES} -stream acceptance/.
+	ginkgo -nodes ${GINKGO_NODES} -stream --flakeAttempts=2 acceptance/.
 
 generate:
 	go generate ./...

--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -60,7 +60,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	fmt.Printf("Ensuring a cluster for node %d\n", config.GinkgoConfig.ParallelNode)
 	ensureCluster()
 	os.Setenv("KUBECONFIG", nodeTmpDir+"/kubeconfig")
-	warmupBuilder()
 
 	os.Setenv("CARRIER_CONFIG", nodeTmpDir+"/carrier.yaml")
 
@@ -256,37 +255,4 @@ func FailWithReport(message string, callerSkip ...int) {
 	}
 
 	Fail(message, callerSkip...)
-}
-
-// This function creates a dummy Job using the buildpack builder image
-// in order to avoid pulling it the first time we try to stage an application.
-// This makes tests more reliable avoiding timeouts related to pulling big
-// images.
-func warmupBuilder() {
-	fmt.Println("Creating a warm up job for the builder image")
-	path, err := helpers.CreateTmpFile(`
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: builder-warmup
-spec:
-  template:
-    spec:
-      containers:
-      - name: builder-warmup
-        image: quay.io/asgardtech/paketobuildpacks-builder:full-cf
-        command: ["/bin/ls"]
-      restartPolicy: Never
-  backoffLimit: 1
-`)
-	if err != nil {
-		panic(err.Error())
-	}
-	defer os.Remove(path)
-
-	out, err := helpers.Kubectl("apply -f " + path)
-	Expect(err).ToNot(HaveOccurred(), out)
-	out, err = helpers.Kubectl("wait --for=condition=complete --timeout=1000s job/builder-warmup")
-	Expect(err).ToNot(HaveOccurred(), out)
-	fmt.Println("Builder warmed up")
 }

--- a/internal/duration/duration.go
+++ b/internal/duration/duration.go
@@ -15,7 +15,8 @@ const (
 	serviceSecret    = 5 * time.Minute
 	serviceProvision = 5 * time.Minute
 	podReady         = 5 * time.Minute
-	appBuilt         = 33 * time.Minute
+	appBuilt         = 10 * time.Minute
+	warmupJobReady   = 30 * time.Minute
 
 	// Fixed. __Not__ affected by the multiplier.
 	pollInterval = 3 * time.Second
@@ -45,6 +46,13 @@ func ToAppBuilt() time.Duration {
 // a system domain
 func ToPodReady() time.Duration {
 	return Multiplier() * podReady
+}
+
+// ToWarmupJobReady return the duration to wait until the builder image
+// warm up job is Complete. The time it takes for that Job to complete depends
+// on the network speed of the cluster so be generous here.
+func ToWarmupJobReady() time.Duration {
+	return Multiplier() * warmupJobReady
 }
 
 // ToSystemDomain returns the duration to wait until giving on getting

--- a/kubernetes/cluster.go
+++ b/kubernetes/cluster.go
@@ -17,6 +17,7 @@ import (
 	minikube "github.com/suse/carrier/kubernetes/platform/minikube"
 	"github.com/suse/carrier/paas/ui"
 
+	apibatchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	typedbatchv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
@@ -144,6 +146,24 @@ func (c *Cluster) IsPodRunning(podName, namespace string) wait.ConditionFunc {
 	}
 }
 
+// IsJobCompleted returns a condition function that indicates whether the given
+// Job is in Completed state.
+func (c *Cluster) IsJobCompleted(client *typedbatchv1.BatchV1Client, jobName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		job, err := client.Jobs(namespace).Get(context.Background(), jobName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		for _, condition := range job.Status.Conditions {
+			if condition.Type == apibatchv1.JobComplete && condition.Status == v1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}
+
 func (c *Cluster) PodExists(namespace, selector string) wait.ConditionFunc {
 	return func() (bool, error) {
 		podList, err := c.ListPods(namespace, selector)
@@ -230,6 +250,14 @@ func (c *Cluster) WaitForSecret(namespace, secretName string, timeout time.Durat
 // Returns an error if the pod never enters the running state.
 func (c *Cluster) WaitForPodRunning(namespace, podName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, c.IsPodRunning(podName, namespace))
+}
+
+func (c *Cluster) WaitForJobCompleted(namespace, jobName string, timeout time.Duration) error {
+	client, err := typedbatchv1.NewForConfig(c.RestConfig)
+	if err != nil {
+		return err
+	}
+	return wait.PollImmediate(time.Second, timeout, c.IsJobCompleted(client, jobName, namespace))
 }
 
 // ListPods returns the list of currently scheduled or running pods in `namespace` with the given selector


### PR DESCRIPTION
otherwise the first time the user pushes an app the (big) buildpack
buidler image will have to be pulled for the first time.

On a warmed up cluster 30 minutes to stage an app should be too much. It
was introduced because test cluster were not warmed up and they timed
out. We need them to fail earlier now in order to retry flakes with
Ginkgo.