### PR TITLE
Listing services classes and plans

### DIFF
--- a/acceptance/service_classes_test.go
+++ b/acceptance/service_classes_test.go
@@ -1,0 +1,33 @@
+package acceptance_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Service Classes, and Plans", func() {
+	var org = "apps-org"
+	BeforeEach(func() {
+		setupAndTargetOrg(org)
+		setupInClusterServices()
+	})
+
+	Describe("service-classes", func() {
+		It("shows all available service classes", func() {
+			out, err := Carrier("service-classes", "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("mariadb"))
+			Expect(out).To(MatchRegexp("Helm Chart for mariadb"))
+			Expect(out).To(MatchRegexp("minibroker"))
+		})
+	})
+
+	Describe("service-plans", func() {
+		It("shows all available service plans for a class", func() {
+			out, err := Carrier("service-plans mariadb", "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("10-3-22"))
+			Expect(out).To(MatchRegexp("MariaDB Server is intended"))
+		})
+	})
+})

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -49,9 +49,15 @@ func setupInClusterServices() {
 	out, err := Carrier("enable services-incluster", "")
 	Expect(err).ToNot(HaveOccurred(), out)
 
-	// Wait until plans appear
+	// Wait until classes appear
 	Eventually(func() error {
 		_, err = helpers.Kubectl("get clusterserviceclass mariadb")
+		return err
+	}, "5m").ShouldNot(HaveOccurred())
+
+	// Wait until plans appear
+	Eventually(func() error {
+		_, err = helpers.Kubectl("get clusterserviceplan mariadb-10-3-22")
 		return err
 	}, "5m").ShouldNot(HaveOccurred())
 }

--- a/cmd/internal/client/bind-service.go
+++ b/cmd/internal/client/bind-service.go
@@ -40,27 +40,24 @@ var CmdBindService = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		if len(args) == 1 {
-			// #args == 1: app name.
-			app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
-			defer func() {
-				if cleanup != nil {
-					cleanup()
-				}
-			}()
-
-			matches := app.AppsMatching(toComplete)
-			return matches, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// #args == 0: service name.
-
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 1 {
+			// #args == 1: app name.
+			matches := app.AppsMatching(toComplete)
+			return matches, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		// #args == 0: service name.
 
 		matches := app.ServiceMatching(toComplete)
 

--- a/cmd/internal/client/create-service.go
+++ b/cmd/internal/client/create-service.go
@@ -53,4 +53,42 @@ var CmdCreateService = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 2 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 2 {
+			// #args == 2: service plan name.
+
+			app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+			defer func() {
+				if cleanup != nil {
+					cleanup()
+				}
+			}()
+
+			matches := app.ServicePlanMatching(args[1], toComplete)
+
+			return matches, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 1 {
+			// #args == 2: service class name.
+
+			app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+			defer func() {
+				if cleanup != nil {
+					cleanup()
+				}
+			}()
+
+			matches := app.ServiceClassMatching(toComplete)
+
+			return matches, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		// #args == 0: service name. new. nothing to match
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 }

--- a/cmd/internal/client/create-service.go
+++ b/cmd/internal/client/create-service.go
@@ -58,37 +58,30 @@ var CmdCreateService = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
+		if len(args) == 0 {
+			// #args == 0: service name. new. nothing to match
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		if len(args) == 2 {
 			// #args == 2: service plan name.
-
-			app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
-			defer func() {
-				if cleanup != nil {
-					cleanup()
-				}
-			}()
-
 			matches := app.ServicePlanMatching(args[1], toComplete)
-
 			return matches, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		if len(args) == 1 {
-			// #args == 2: service class name.
-
-			app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
-			defer func() {
-				if cleanup != nil {
-					cleanup()
-				}
-			}()
-
-			matches := app.ServiceClassMatching(toComplete)
-
-			return matches, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// #args == 0: service name. new. nothing to match
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		// #args == 1: service class name.
+		matches := app.ServiceClassMatching(toComplete)
+		return matches, cobra.ShellCompDirectiveNoFileComp
 	},
 }

--- a/cmd/internal/client/delete-service.go
+++ b/cmd/internal/client/delete-service.go
@@ -48,12 +48,17 @@ var CmdDeleteService = &cobra.Command{
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 
 		matches := app.ServiceMatching(toComplete)
 

--- a/cmd/internal/client/delete.go
+++ b/cmd/internal/client/delete.go
@@ -38,12 +38,16 @@ var CmdDeleteApp = &cobra.Command{
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 
 		matches := app.AppsMatching(toComplete)
 

--- a/cmd/internal/client/service-classes.go
+++ b/cmd/internal/client/service-classes.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/suse/carrier/paas"
+)
+
+var ()
+
+// CmdServiceClasses implements the carrier service-classes command
+var CmdServiceClasses = &cobra.Command{
+	Use:   "service-classes",
+	Short: "Lists the available service classes",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, cleanup, err := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.ServiceClasses()
+		if err != nil {
+			return errors.Wrap(err, "error listing service classes")
+		}
+
+		return nil
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}

--- a/cmd/internal/client/service-plans.go
+++ b/cmd/internal/client/service-plans.go
@@ -38,12 +38,17 @@ var CmdServicePlans = &cobra.Command{
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 
 		matches := app.ServiceClassMatching(toComplete)
 

--- a/cmd/internal/client/service-plans.go
+++ b/cmd/internal/client/service-plans.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/suse/carrier/paas"
+)
+
+var ()
+
+// CmdServicePlans implements the carrier service-plans command
+var CmdServicePlans = &cobra.Command{
+	Use:   "service-plans CLASS",
+	Short: "Lists all plans provided by the named service class",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, cleanup, err := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.ServicePlans(args[0])
+		if err != nil {
+			return errors.Wrap(err, "error listing plan")
+		}
+
+		return nil
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		matches := app.ServiceClassMatching(toComplete)
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	},
+}

--- a/cmd/internal/client/service.go
+++ b/cmd/internal/client/service.go
@@ -39,12 +39,17 @@ var CmdService = &cobra.Command{
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 
 		matches := app.ServiceMatching(toComplete)
 

--- a/cmd/internal/client/target.go
+++ b/cmd/internal/client/target.go
@@ -43,12 +43,17 @@ var CmdTarget = &cobra.Command{
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 
 		matches := app.OrgsMatching(toComplete)
 

--- a/cmd/internal/client/unbind-service.go
+++ b/cmd/internal/client/unbind-service.go
@@ -40,28 +40,24 @@ var CmdUnbindService = &cobra.Command{
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		if len(args) == 1 {
-			// #args == 1: app name.
-			app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
-			defer func() {
-				if cleanup != nil {
-					cleanup()
-				}
-			}()
-
-			matches := app.AppsMatching(toComplete)
-			return matches, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		// #args == 0: service name.
-
-		app, cleanup, _ := paas.NewCarrierClient(cmd.Flags())
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
 		defer func() {
 			if cleanup != nil {
 				cleanup()
 			}
 		}()
 
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 1 {
+			// #args == 1: app name.
+			matches := app.AppsMatching(toComplete)
+			return matches, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		// #args == 0: service name.
 		matches := app.ServiceMatching(toComplete)
 
 		return matches, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,6 +70,7 @@ func Execute() {
 	rootCmd.AddCommand(client.CmdUnbindService)
 	rootCmd.AddCommand(client.CmdServices)
 	rootCmd.AddCommand(client.CmdService)
+	rootCmd.AddCommand(client.CmdServiceClasses)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ func Execute() {
 	rootCmd.AddCommand(client.CmdServices)
 	rootCmd.AddCommand(client.CmdService)
 	rootCmd.AddCommand(client.CmdServiceClasses)
+	rootCmd.AddCommand(client.CmdServicePlans)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/internal/services/catalog_service.go
+++ b/internal/services/catalog_service.go
@@ -130,8 +130,9 @@ func ListClasses(kubeClient *kubernetes.Cluster) (ServiceClassList, error) {
 		// external name also.
 		//
 		// Consequence of hiding the hash/uuid name from the
-		// user here: `ClassLookup` has to try twice when
-		// searching for a class.
+		// user here: `ClassLookup` finds a class by listing
+		// all and filtering, instead of `get`ing it directly
+		// by its name.
 
 		externalName := spec["externalName"].(string)
 		description := spec["description"].(string)

--- a/internal/services/catalog_service.go
+++ b/internal/services/catalog_service.go
@@ -94,16 +94,6 @@ func (sc *ServiceClass) ListPlans() (ServicePlanList, error) {
 	}
 
 	return result, nil
-
-	// spec:
-	//   clusterServiceBrokerName: minibroker
-	//   clusterServiceClassRef:
-	//     name: mongodb
-	//   description: NoSQL document-oriented database that stores JSON-like documents with
-	//     dynamic schemas, simplifying the integration of data in content-driven applications.
-	//   externalID: mongodb-4-0-12
-	//   externalName: 4-0-12
-	//   free: true
 }
 
 // ListClasses returns a ServiceClassList of all available catalog service classes
@@ -152,26 +142,6 @@ func ListClasses(kubeClient *kubernetes.Cluster) (ServiceClassList, error) {
 	}
 
 	return result, nil
-
-	//	metadata:
-	//	  creationTimestamp: "2021-03-15T13:06:46Z"
-	//	  generation: 1
-	//	  labels:
-	//	    servicecatalog.k8s.io/spec.clusterServiceBrokerName: d42e833047334b72abd9b8d804264d4dc8077517a5ef767ee76ba44d
-	// *1	    servicecatalog.k8s.io/spec.externalID: 431ba23818d0e82e05612ddd029dfb1506d2f255d96205606e1ee464
-	//	    servicecatalog.k8s.io/spec.externalName: 431ba23818d0e82e05612ddd029dfb1506d2f255d96205606e1ee464
-	//	spec:
-	//	  bindable: true
-	//	  bindingRetrievable: false
-	// **	  clusterServiceBrokerName: minibroker
-	// **	  description: Helm Chart for redis
-	//	  externalID: redis
-	// **	  externalName: redis
-	//	  planUpdatable: false
-	//
-	// Ad *1: This hash is the value of the
-	// 	`servicecatalog.k8s.io/spec.clusterServiceClassRef.name`
-	// label of the assocoiated plans.
 }
 
 func ClassLookup(kubeClient *kubernetes.Cluster, serviceClassName string) (*ServiceClass, error) {

--- a/paas/client.go
+++ b/paas/client.go
@@ -169,7 +169,6 @@ func (c *CarrierClient) ServiceClasses() error {
 	c.ui.Note().
 		Msg("Listing service classes")
 
-	details.Info("validate")
 	serviceClasses, err := services.ListClasses(c.kubeClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to list service classes")
@@ -177,7 +176,7 @@ func (c *CarrierClient) ServiceClasses() error {
 
 	// todo: sort service classes by name before display
 
-	details.Info("list service secrets")
+	details.Info("list service classes")
 
 	msg := c.ui.Success().WithTable("Name", "Description", "Broker")
 	for _, sc := range serviceClasses {
@@ -244,7 +243,7 @@ func (c *CarrierClient) Services() error {
 
 	// todo: sort services by name before display
 
-	details.Info("list service secrets")
+	details.Info("list services")
 
 	msg := c.ui.Success().WithTable("Name", "Applications")
 	for _, s := range orgServices {
@@ -695,7 +694,7 @@ func (c *CarrierClient) Apps() error {
 		return err
 	}
 
-	details.Info("gitea list org repos")
+	details.Info("list applications")
 	apps, err := application.List(c.kubeClient, c.giteaClient, c.config.Org)
 	if err != nil {
 		return errors.Wrap(err, "failed to list apps")
@@ -954,7 +953,7 @@ func (c *CarrierClient) Push(app string, path string) error {
 	}
 	defer stopFunc()
 
-	details.Info("wait for apps")
+	details.Info("wait for app")
 	err = c.waitForApp(c.config.Org, app)
 	if err != nil {
 		return errors.Wrap(err, "waiting for app failed")

--- a/paas/client.go
+++ b/paas/client.go
@@ -104,6 +104,11 @@ func (c *CarrierClient) ServicePlans(serviceClassName string) error {
 		return nil
 	}
 
+	if serviceClass == nil {
+		c.ui.Exclamation().Msg("Service Class does not exist")
+		return nil
+	}
+
 	servicePlans, err := serviceClass.ListPlans()
 	if err != nil {
 		return errors.Wrap(err, "failed to list service plans")

--- a/paas/client.go
+++ b/paas/client.go
@@ -87,6 +87,35 @@ func NewCarrierClient(flags *pflag.FlagSet) (*CarrierClient, func(), error) {
 	}, nil
 }
 
+// ServiceClasses gets all service classes in the cluster
+func (c *CarrierClient) ServiceClasses() error {
+	log := c.Log.WithName("ServiceClasses")
+	log.Info("start")
+	defer log.Info("return")
+	details := log.V(1) // NOTE: Increment of level, not absolute.
+
+	c.ui.Note().
+		Msg("Listing service classes")
+
+	details.Info("validate")
+	serviceClasses, err := services.ListClasses(c.kubeClient)
+	if err != nil {
+		return errors.Wrap(err, "failed to list service classes")
+	}
+
+	// todo: sort service classes by name before display
+
+	details.Info("list service secrets")
+
+	msg := c.ui.Success().WithTable("Name", "Description", "Broker")
+	for _, sc := range serviceClasses {
+		msg = msg.WithTableRow(sc.Name, sc.Description, sc.Broker)
+	}
+	msg.Msg("Carrier Service Classes:")
+
+	return nil
+}
+
 // Services gets all Carrier services in the targeted org
 func (c *CarrierClient) Services() error {
 	log := c.Log.WithName("Services").WithValues("Organization", c.config.Org)

--- a/paas/client.go
+++ b/paas/client.go
@@ -99,7 +99,7 @@ func (c *CarrierClient) Services() error {
 		Msg("Listing services")
 
 	details.Info("validate")
-	err := c.ensureGoodOrg(c.config.Org, "Unable to list applications.")
+	err := c.ensureGoodOrg(c.config.Org, "Unable to list services.")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #215 

- New command `service-classes`
- New command `service-plans CLASS`
- Extended command `create-service` with command completion of class and plan arguments.

TODO: More acceptance tests.
