### PR TITLE
Fix Un/bind service in conflict

### DIFF
--- a/internal/application/application.go
+++ b/internal/application/application.go
@@ -178,14 +178,17 @@ func (a *Application) Bind(service interfaces.Service) error {
 			metav1.UpdateOptions{},
 		)
 
-		if err == nil || !apierrors.IsConflict(err) {
+		if err == nil {
+			break
+		}
+		if !apierrors.IsConflict(err) {
 			return err
 		}
 
 		// Found a conflict. Try again from the beginning.
 	}
 
-	// Not reachable
+	return nil
 }
 
 // Lookup locates an Application by org and name


### PR DESCRIPTION
Fixes #221 

It is expected that the loop will resolve quickly. The most likely reason for it is that the service is bound/unbound concurrently. In that case the loop breaks at the recheck for service un/bound.
