### PR TITLE
Issue 217: restrict self hosted to known users

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    if: contains(["kkaempf", "jimmikarily", "andreas-kupries", "rohitsakala", "svollath", "thardeck"], "${{ github.actor }}")
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: self-hosted
-    if: contains(["kkaempf", "jimmikarily", "andreas-kupries", "rohitsakala", "svollath", "thardeck"], "${{ github.actor }}")
+    if: contains(["kkaempf", "jimmykarily", "andreas-kupries", "rohitsakala", "svollath", "thardeck"], "${{ github.actor }}")
 
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,4 @@ jobs:
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          make test-acceptance
+          GINKGO_NODES=6 make test-acceptance


### PR DESCRIPTION
Run `main` CI task on self-hosted runners for known users

Also bump GINGKO_NODES to 6. The current tests don't make use of more than 6 nodes.

This brings the CI time down to approx. 8 minutes.