### PR TITLE
Added command to show app details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,11 @@ test: lint
 	ginkgo ./cmd/internal/client/ ./tools/ ./helpers/ ./kubernetes/
 
 GINKGO_NODES ?= 2
-test-acceptance:
+test-acceptance: showfocus
 	ginkgo -nodes ${GINKGO_NODES} -stream --flakeAttempts=2 acceptance/.
+
+showfocus:
+	@if test `cat acceptance/*.go | grep -c FIt` -gt 0 ; then echo ; echo 'Focus:' ; grep FIt acceptance/* ; echo ; fi
 
 generate:
 	go generate ./...

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -10,6 +10,7 @@ var _ = Describe("Apps", func() {
 	BeforeEach(func() {
 		setupAndTargetOrg(org)
 	})
+
 	Describe("push and delete", func() {
 		var appName string
 		BeforeEach(func() {
@@ -42,10 +43,51 @@ var _ = Describe("Apps", func() {
 			Expect(out).To(MatchRegexp("Unbound"))
 
 			Eventually(func() string {
-				out, err := Carrier("apps", "")
+				out, err := Carrier("apps list", "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "1m").ShouldNot(MatchRegexp(`.*%s.*`, appName))
+		})
+	})
+
+	Describe("list and show", func() {
+		var appName string
+		var serviceCustomName string
+		BeforeEach(func() {
+			appName = newAppName()
+			serviceCustomName = newServiceName()
+			makeApp(appName)
+			makeCustomService(serviceCustomName)
+			bindAppService(appName, serviceCustomName, org)
+		})
+
+		AfterEach(func() {
+			deleteApp(appName)
+			cleanupService(serviceCustomName)
+		})
+
+		It("lists all apps", func() {
+			out, err := Carrier("apps list", "")
+			Expect(err).ToNot(HaveOccurred(), out)
+			Expect(out).To(MatchRegexp("Listing applications"))
+			Expect(out).To(MatchRegexp(" " + appName + " "))
+			Expect(out).To(MatchRegexp(" " + serviceCustomName + " "))
+		})
+
+		It("shows the details of an app", func() {
+			out, err := Carrier("apps show "+appName, "")
+			Expect(err).ToNot(HaveOccurred(), out)
+
+			Expect(out).To(MatchRegexp("Show application details"))
+			Expect(out).To(MatchRegexp("Application: " + appName))
+			Expect(out).To(MatchRegexp(`Services .*\|.* ` + serviceCustomName))
+			Expect(out).To(MatchRegexp(`Routes .*\|.* ` + appName))
+
+			Eventually(func() string {
+				out, err = Carrier("apps show "+appName, "")
+				Expect(err).ToNot(HaveOccurred(), out)
+				return out
+			}, "1m").Should(MatchRegexp(`Status .*\|.* 1\/1`))
 		})
 	})
 })

--- a/acceptance/apps_test.go
+++ b/acceptance/apps_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Apps", func() {
 			Expect(out).To(MatchRegexp("Unbound"))
 
 			Eventually(func() string {
-				out, err := Carrier("apps list", "")
+				out, err := Carrier("app list", "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "1m").ShouldNot(MatchRegexp(`.*%s.*`, appName))
@@ -67,7 +67,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("lists all apps", func() {
-			out, err := Carrier("apps list", "")
+			out, err := Carrier("app list", "")
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).To(MatchRegexp("Listing applications"))
 			Expect(out).To(MatchRegexp(" " + appName + " "))
@@ -75,7 +75,7 @@ var _ = Describe("Apps", func() {
 		})
 
 		It("shows the details of an app", func() {
-			out, err := Carrier("apps show "+appName, "")
+			out, err := Carrier("app show "+appName, "")
 			Expect(err).ToNot(HaveOccurred(), out)
 
 			Expect(out).To(MatchRegexp("Show application details"))
@@ -84,7 +84,7 @@ var _ = Describe("Apps", func() {
 			Expect(out).To(MatchRegexp(`Routes .*\|.* ` + appName))
 
 			Eventually(func() string {
-				out, err = Carrier("apps show "+appName, "")
+				out, err = Carrier("app show "+appName, "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "1m").Should(MatchRegexp(`Status .*\|.* 1\/1`))

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Bounds between Apps & Services", func() {
 			Expect(out).To(MatchRegexp(serviceName + `.*` + appName))
 
 			Eventually(func() string {
-				out, err = Carrier("apps", "")
+				out, err = Carrier("apps list", "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "1m").Should(MatchRegexp(appName + `.*\|.*1\/1.*\|.*` + serviceName))

--- a/acceptance/bindings_test.go
+++ b/acceptance/bindings_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Bounds between Apps & Services", func() {
 			Expect(out).To(MatchRegexp(serviceName + `.*` + appName))
 
 			Eventually(func() string {
-				out, err = Carrier("apps list", "")
+				out, err = Carrier("app list", "")
 				Expect(err).ToNot(HaveOccurred(), out)
 				return out
 			}, "1m").Should(MatchRegexp(appName + `.*\|.*1\/1.*\|.*` + serviceName))

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -72,7 +72,7 @@ func makeApp(appName string) {
 
 	// And check presence
 
-	out, err = Carrier("apps", "")
+	out, err = Carrier("apps list", "")
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*`))
 }
@@ -149,7 +149,7 @@ func deleteApp(appName string) {
 	// TODO: Fix `carrier delete` from returning before the app is deleted #131
 
 	Eventually(func() string {
-		out, err := Carrier("apps", "")
+		out, err := Carrier("apps list", "")
 		Expect(err).ToNot(HaveOccurred(), out)
 		return out
 	}, "1m").ShouldNot(MatchRegexp(`.*%s.*`, appName))

--- a/acceptance/utilities_test.go
+++ b/acceptance/utilities_test.go
@@ -72,7 +72,7 @@ func makeApp(appName string) {
 
 	// And check presence
 
-	out, err = Carrier("apps list", "")
+	out, err = Carrier("app list", "")
 	Expect(err).ToNot(HaveOccurred(), out)
 	Expect(out).To(MatchRegexp(appName + `.*\|.*1\/1.*\|.*`))
 }
@@ -149,7 +149,7 @@ func deleteApp(appName string) {
 	// TODO: Fix `carrier delete` from returning before the app is deleted #131
 
 	Eventually(func() string {
-		out, err := Carrier("apps list", "")
+		out, err := Carrier("app list", "")
 		Expect(err).ToNot(HaveOccurred(), out)
 		return out
 	}, "1m").ShouldNot(MatchRegexp(`.*%s.*`, appName))

--- a/acceptance/wordpress_test.go
+++ b/acceptance/wordpress_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Wordpress", func() {
 		out, err := Carrier(fmt.Sprintf("push %s --verbosity 1", wordpress.Name), wordpress.Dir)
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		out, err = Carrier("apps list", "")
+		out, err = Carrier("app list", "")
 		Expect(err).ToNot(HaveOccurred(), out)
 		Expect(out).To(MatchRegexp(wordpress.Name + `.*\|.*1\/1.*\|.*`))
 

--- a/acceptance/wordpress_test.go
+++ b/acceptance/wordpress_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Wordpress", func() {
 		out, err := Carrier(fmt.Sprintf("push %s --verbosity 1", wordpress.Name), wordpress.Dir)
 		Expect(err).ToNot(HaveOccurred(), out)
 
-		out, err = Carrier("apps", "")
+		out, err = Carrier("apps list", "")
 		Expect(err).ToNot(HaveOccurred(), out)
 		Expect(out).To(MatchRegexp(wordpress.Name + `.*\|.*1\/1.*\|.*`))
 

--- a/cmd/internal/client/apps.go
+++ b/cmd/internal/client/apps.go
@@ -8,9 +8,25 @@ import (
 
 var ()
 
-// CmdApps implements the carrier app command
-var CmdApps = &cobra.Command{
-	Use:   "apps",
+// CmdApp implements the carrier -app command
+var CmdApp = &cobra.Command{
+	Use:           "apps",
+	Aliases:       []string{"app"},
+	Short:         "Carrier application features",
+	Long:          `Manage carrier application`,
+	Args:          cobra.ExactArgs(0),
+	SilenceErrors: true,
+	SilenceUsage:  true,
+}
+
+func init() {
+	CmdApp.AddCommand(CmdAppsShow)
+	CmdApp.AddCommand(CmdAppsList)
+}
+
+// CmdAppsList implements the carrier `apps list` command
+var CmdAppsList = &cobra.Command{
+	Use:   "list",
 	Short: "Lists all applications",
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -34,4 +50,52 @@ var CmdApps = &cobra.Command{
 	},
 	SilenceErrors: true,
 	SilenceUsage:  true,
+}
+
+// CmdAppsShow implements the carrier `apps show` command
+var CmdAppsShow = &cobra.Command{
+	Use:   "show NAME",
+	Short: "Describe the named application",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, cleanup, err := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return errors.Wrap(err, "error initializing cli")
+		}
+
+		err = client.AppShow(args[0])
+		if err != nil {
+			return errors.Wrap(err, "error listing apps")
+		}
+
+		return nil
+	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		app, cleanup, err := paas.NewCarrierClient(cmd.Flags())
+		defer func() {
+			if cleanup != nil {
+				cleanup()
+			}
+		}()
+
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		matches := app.AppsMatching(toComplete)
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	},
 }

--- a/cmd/internal/client/apps.go
+++ b/cmd/internal/client/apps.go
@@ -20,12 +20,12 @@ var CmdApp = &cobra.Command{
 }
 
 func init() {
-	CmdApp.AddCommand(CmdAppsShow)
-	CmdApp.AddCommand(CmdAppsList)
+	CmdApp.AddCommand(CmdAppShow)
+	CmdApp.AddCommand(CmdAppList)
 }
 
-// CmdAppsList implements the carrier `apps list` command
-var CmdAppsList = &cobra.Command{
+// CmdAppList implements the carrier `apps list` command
+var CmdAppList = &cobra.Command{
 	Use:   "list",
 	Short: "Lists all applications",
 	Args:  cobra.ExactArgs(0),
@@ -52,8 +52,8 @@ var CmdAppsList = &cobra.Command{
 	SilenceUsage:  true,
 }
 
-// CmdAppsShow implements the carrier `apps show` command
-var CmdAppsShow = &cobra.Command{
+// CmdAppShow implements the carrier `apps show` command
+var CmdAppShow = &cobra.Command{
 	Use:   "show NAME",
 	Short: "Describe the named application",
 	Args:  cobra.ExactArgs(1),

--- a/cmd/internal/client/apps.go
+++ b/cmd/internal/client/apps.go
@@ -10,8 +10,8 @@ var ()
 
 // CmdApp implements the carrier -app command
 var CmdApp = &cobra.Command{
-	Use:           "apps",
-	Aliases:       []string{"app"},
+	Use:           "app",
+	Aliases:       []string{"apps"},
 	Short:         "Carrier application features",
 	Long:          `Manage carrier application`,
 	Args:          cobra.ExactArgs(0),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func Execute() {
 	rootCmd.AddCommand(client.CmdCreateOrg)
 	rootCmd.AddCommand(client.CmdPush)
 	rootCmd.AddCommand(client.CmdDeleteApp)
-	rootCmd.AddCommand(client.CmdApps)
+	rootCmd.AddCommand(client.CmdApp)
 	rootCmd.AddCommand(client.CmdTarget)
 	rootCmd.AddCommand(client.CmdEnable)
 	rootCmd.AddCommand(client.CmdDisable)


### PR DESCRIPTION
Fixes #156 

Beyond the new command to show details of a single app this PR reorgs the `apps` command and the new command into a new hierarchy:
```
    apps
        list
        show
```

While the `push` command was not moved into this hierachy, it could, maybe should.

Existing tests were updated to match the new command name for `apps list`.
Tests added to cover the new `apps show` command.

Fix to the workpress test, it was not setting up an org for itself. Seen only when focusing on it alone.

Extended the Makefile with a `showfous` target to tell us which tests, if any, are focused.
This is now a dependency of the `test-acceptance` target.

Mostly :heavy_check_mark: for a local :cat2: Wordpress test fails in pushing the app, does not seem to be related.

And :heavy_check_mark: :cat2: on our gh runner :fireworks: 

