### PR TITLE
fix: do not assume 'master' as current git branch

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,7 @@
     - [Minikube](#minikube)
     - [Kind](#kind)
     - [MircoK8s](#mircok8s)
+  - [Prerequisites for Carrier](#prerequisites)
 
 ## Provision of External IP for LoadBalancer service type in Kubernetes
 
@@ -79,3 +80,6 @@ microk8s enable metallb:${IP}/16
 ```
 
 
+## Prerequisites
+
+- git 2.22 or later

--- a/internal/cli/clients/client.go
+++ b/internal/cli/clients/client.go
@@ -1274,8 +1274,8 @@ git fetch --all
 git reset --soft carrier/main
 git add --all
 git commit -m "pushed at %s"
-git push carrier master:main
-`, tmpDir, u.String(), time.Now().Format("20060102150405")))
+git push carrier %s:main
+`, tmpDir, u.String(), time.Now().Format("20060102150405"), "`git branch --show-current`"))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Instead use `git branch --show-current` (needs git 2.22 or later)
to find the current branch name.

Make git requirement explicit in docs.

Fixes #243