### PR TITLE
docs: explicitly list external commands Carrier depends on

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -82,4 +82,11 @@ microk8s enable metallb:${IP}/16
 
 ## Prerequisites
 
+- bash
 - git 2.22 or later
+- helm (3.0 or later)
+- kubectl (1.18 or later)
+- openssl
+
+Where no explicit version number is given, a release not older than
+~2 years is assumed.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,6 +78,7 @@ func checkDependencies() error {
 	dependencies := []struct {
 		CommandName string
 	}{
+		// update the 'prerequisites' of docs/install.md if you make changes here
 		{CommandName: "kubectl"},
 		{CommandName: "helm"},
 		{CommandName: "sh"},


### PR DESCRIPTION
Follow up from https://github.com/SUSE/carrier/pull/244#discussion_r604643477